### PR TITLE
fix: Use better regex for valid identifier checking tables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ python = ">=3.7"
 arrow = "^1.2.3"
 psycopg2 = "^2.9.5"
 singer-python = {git = "https://github.com/peliqan-io/singer-python", branch = "master"}
+regex = "2023.6.3"
 
 [tool.poetry.group.tests]
 optional = true

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -262,7 +262,8 @@ class PostgresTarget(SQLInterface):
                             ))
 
                     for key_property in stream_buffer.key_properties:
-                        canonicalized_key, remote_column_schema = self.fetch_column_from_path((key_property,), current_table_schema)
+                        canonicalized_key, remote_column_schema = self.fetch_column_from_path((key_property,),
+                                                                                              current_table_schema)
                         if self.json_schema_to_sql_type(remote_column_schema) \
                                 != self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property]):
                             raise PostgresError(

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -262,14 +262,13 @@ class PostgresTarget(SQLInterface):
                             ))
 
                     for key_property in stream_buffer.key_properties:
-                        canonicalized_key, remote_column_schema = self.fetch_column_from_path((key_property,),
-                                                                                                current_table_schema)
+                        canonicalized_key, remote_column_schema = self.fetch_column_from_path((key_property,), current_table_schema)
                         if self.json_schema_to_sql_type(remote_column_schema) \
                                 != self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property]):
                             raise PostgresError(
                                 ('`key_properties` type change detected for "{}". ' +
-                                    'Existing values are: {}. ' +
-                                    'Streamed values are: {}, {}, {}').format(
+                                 'Existing values are: {}. ' +
+                                 'Streamed values are: {}, {}, {}').format(
                                     key_property,
                                     json_schema.get_type(current_table_schema['schema']['properties'][key_property]),
                                     json_schema.get_type(stream_buffer.schema['properties'][key_property]),
@@ -303,11 +302,11 @@ class PostgresTarget(SQLInterface):
                 self.LOGGER.info('Root table name {}'.format(root_table_name))
 
                 written_batches_details = self.write_batch_helper(cur,
-                                                                    root_table_name,
-                                                                    stream_buffer.schema,
-                                                                    stream_buffer.key_properties,
-                                                                    stream_buffer.get_batch(),
-                                                                    {'version': target_table_version})
+                                                                  root_table_name,
+                                                                  stream_buffer.schema,
+                                                                  stream_buffer.key_properties,
+                                                                  stream_buffer.get_batch(),
+                                                                  {'version': target_table_version})
 
                 cur.execute('COMMIT;')
 

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -240,83 +240,83 @@ class PostgresTarget(SQLInterface):
             return None
 
         with self.conn.cursor() as cur:
-            #try:
-            cur.execute('BEGIN;')
+            try:
+                cur.execute('BEGIN;')
 
-            self.setup_table_mapping_cache(cur)
+                self.setup_table_mapping_cache(cur)
 
-            root_table_name = self.add_table_mapping_helper((stream_buffer.stream,), self.table_mapping_cache)['to']
-            current_table_schema = self.get_table_schema(cur, root_table_name)
+                root_table_name = self.add_table_mapping_helper((stream_buffer.stream,), self.table_mapping_cache)['to']
+                current_table_schema = self.get_table_schema(cur, root_table_name)
 
-            current_table_version = None
+                current_table_version = None
 
-            if current_table_schema:
-                current_table_version = current_table_schema.get('version', None)
+                if current_table_schema:
+                    current_table_version = current_table_schema.get('version', None)
 
-                if set(stream_buffer.key_properties) \
-                        != set(current_table_schema.get('key_properties')):
-                    raise PostgresError(
-                        '`key_properties` change detected. Existing values are: {}. Streamed values are: {}'.format(
-                            current_table_schema.get('key_properties'),
-                            stream_buffer.key_properties
-                        ))
-
-                for key_property in stream_buffer.key_properties:
-                    canonicalized_key, remote_column_schema = self.fetch_column_from_path((key_property,),
-                                                                                            current_table_schema)
-                    if self.json_schema_to_sql_type(remote_column_schema) \
-                            != self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property]):
+                    if set(stream_buffer.key_properties) \
+                            != set(current_table_schema.get('key_properties')):
                         raise PostgresError(
-                            ('`key_properties` type change detected for "{}". ' +
-                                'Existing values are: {}. ' +
-                                'Streamed values are: {}, {}, {}').format(
-                                key_property,
-                                json_schema.get_type(current_table_schema['schema']['properties'][key_property]),
-                                json_schema.get_type(stream_buffer.schema['properties'][key_property]),
-                                self.json_schema_to_sql_type(
-                                    current_table_schema['schema']['properties'][key_property]),
-                                self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property])
+                            '`key_properties` change detected. Existing values are: {}. Streamed values are: {}'.format(
+                                current_table_schema.get('key_properties'),
+                                stream_buffer.key_properties
                             ))
 
-            target_table_version = current_table_version or stream_buffer.max_version
+                    for key_property in stream_buffer.key_properties:
+                        canonicalized_key, remote_column_schema = self.fetch_column_from_path((key_property,),
+                                                                                                current_table_schema)
+                        if self.json_schema_to_sql_type(remote_column_schema) \
+                                != self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property]):
+                            raise PostgresError(
+                                ('`key_properties` type change detected for "{}". ' +
+                                    'Existing values are: {}. ' +
+                                    'Streamed values are: {}, {}, {}').format(
+                                    key_property,
+                                    json_schema.get_type(current_table_schema['schema']['properties'][key_property]),
+                                    json_schema.get_type(stream_buffer.schema['properties'][key_property]),
+                                    self.json_schema_to_sql_type(
+                                        current_table_schema['schema']['properties'][key_property]),
+                                    self.json_schema_to_sql_type(stream_buffer.schema['properties'][key_property])
+                                ))
 
-            self.LOGGER.info('Stream {} ({}) with max_version {} targetting {}'.format(
-                stream_buffer.stream,
-                root_table_name,
-                stream_buffer.max_version,
-                target_table_version
-            ))
+                target_table_version = current_table_version or stream_buffer.max_version
 
-            root_table_name = stream_buffer.stream
-            if current_table_version is not None and \
-                    stream_buffer.max_version is not None:
-                if stream_buffer.max_version < current_table_version:
-                    self.LOGGER.warning('{} - Records from an earlier table version detected.'
-                                        .format(stream_buffer.stream))
-                    cur.execute('ROLLBACK;')
-                    return None
+                self.LOGGER.info('Stream {} ({}) with max_version {} targetting {}'.format(
+                    stream_buffer.stream,
+                    root_table_name,
+                    stream_buffer.max_version,
+                    target_table_version
+                ))
 
-                elif stream_buffer.max_version > current_table_version:
-                    root_table_name += SEPARATOR + str(stream_buffer.max_version)
-                    target_table_version = stream_buffer.max_version
+                root_table_name = stream_buffer.stream
+                if current_table_version is not None and \
+                        stream_buffer.max_version is not None:
+                    if stream_buffer.max_version < current_table_version:
+                        self.LOGGER.warning('{} - Records from an earlier table version detected.'
+                                            .format(stream_buffer.stream))
+                        cur.execute('ROLLBACK;')
+                        return None
 
-            self.LOGGER.info('Root table name {}'.format(root_table_name))
+                    elif stream_buffer.max_version > current_table_version:
+                        root_table_name += SEPARATOR + str(stream_buffer.max_version)
+                        target_table_version = stream_buffer.max_version
 
-            written_batches_details = self.write_batch_helper(cur,
-                                                                root_table_name,
-                                                                stream_buffer.schema,
-                                                                stream_buffer.key_properties,
-                                                                stream_buffer.get_batch(),
-                                                                {'version': target_table_version})
+                self.LOGGER.info('Root table name {}'.format(root_table_name))
 
-            cur.execute('COMMIT;')
+                written_batches_details = self.write_batch_helper(cur,
+                                                                    root_table_name,
+                                                                    stream_buffer.schema,
+                                                                    stream_buffer.key_properties,
+                                                                    stream_buffer.get_batch(),
+                                                                    {'version': target_table_version})
 
-            return written_batches_details
-            # except Exception as ex:
-            #     cur.execute('ROLLBACK;')
-            #     message = 'Exception writing records'
-            #     self.LOGGER.exception(message)
-            #     raise PostgresError(message, ex)
+                cur.execute('COMMIT;')
+
+                return written_batches_details
+            except Exception as ex:
+                cur.execute('ROLLBACK;')
+                message = 'Exception writing records'
+                self.LOGGER.exception(message)
+                raise PostgresError(message, ex)
 
     def activate_version(self, stream_buffer, version):
         with self.conn.cursor() as cur:


### PR DESCRIPTION
Use `regex` package for better regular expression matching.

> SQL identifiers and key words must begin with a letter ( a - z , but also letters with diacritical marks and non-Latin letters) or an underscore ( _ ). Subsequent characters in an identifier or key word can be letters, underscores, digits ( 0 - 9 ), or dollar signs ( $ ).

`re` doesn't allow for non-Latin matching while `regex` does.