### PR TITLE
feat: Date type field

### DIFF
--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -202,7 +202,7 @@ def is_datetime(schema):
 
 def is_date(schema):
     """
-    Given a JSON Schema compatible dict, returns True when schema's type allows being a date-time
+    Given a JSON Schema compatible dict, returns True when schema's type allows being a date
     :param schema: dict, JSON Schema
     :return: Boolean
     """


### PR DESCRIPTION
## Description
The target can handle fields of type "date-time", but for fields from a source tap of type "date", it will create them as a text column and not a DATE column.
Added support for "date" in the target.