### PR TITLE
[Fix] Add Primary Key: Canonicalize identifier the column names

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -455,11 +455,11 @@ class PostgresTarget(SQLInterface):
         return mapping['to']
 
     def add_primary_key(self, cur, table_name, column_names):
-        
+
         cur.execute(sql.SQL('ALTER TABLE {table_schema}.{table_name} ADD PRIMARY KEY ({column_names});').format(
             table_schema=sql.Identifier(self.postgres_schema),
             table_name=sql.Identifier(table_name),
-            column_names=sql.SQL(', ').join(sql.Identifier(column_name) for column_name in column_names)
+            column_names=sql.SQL(', ').join(sql.Identifier(self.canonicalize_identifier(column_name)) for column_name in column_names)
         ))
 
     def _get_update_sql(self, target_table_name, temp_table_name, key_properties, columns, subkeys):

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -629,7 +629,6 @@ class SQLInterface:
             if not existing_table:
                 for column_names in self.new_table_indexes(schema):
                     self.add_index(connection, table_name, column_names)
-                
                 self.add_primary_key(connection, table_name, schema.get('key_properties', None))
 
             return self._get_table_schema(connection, table_name)


### PR DESCRIPTION
## Description
While trying to sync a case-sensitive stream (Exact's PurchaseEntries), the target threw the following error:
`psycopg2.errors.UndefinedColumn: column "EntryID" named in key does not exist`

This is because the colum_names in the add_primary_key query were not canonicalized.