### PR TITLE
[PQ-1524] [Fix] issues with very long table names

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -714,8 +714,8 @@ class PostgresTarget(SQLInterface):
         index_name = 'tp_{}_{}_idx'.format(table_name, "_".join(column_names))
 
         if len(index_name) > self.IDENTIFIER_FIELD_LENGTH:
-            index_name_hash = hashlib.sha1(index_name.encode('utf-8')).hexdigest()[0:60]
-            index_name = 'tp_{}'.format(index_name_hash)
+            index_name = self.canonicalize_identifier(str(uuid.uuid4()))
+            index_name = 'tp_{}'.format(index_name)
 
         cur.execute(sql.SQL('''
             CREATE INDEX {index_name}

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -366,7 +366,7 @@ class PostgresTarget(SQLInterface):
                         old_table_name = table_name + SEPARATOR + 'old'
                         if len(old_table_name) > self.IDENTIFIER_FIELD_LENGTH:
                             unique_suffix = self.canonicalize_identifier(str(uuid.uuid4()) + SEPARATOR + 'old')
-                            old_table_name = table_name[:len(table_name) - len(unique_suffix)]
+                            old_table_name = table_name[:self.IDENTIFIER_FIELD_LENGTH - len(unique_suffix)]
                             old_table_name += unique_suffix
 
                         cur.execute(sql.SQL('''

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -348,6 +348,7 @@ class PostgresTarget(SQLInterface):
                         version))
                 else:
                     versioned_root_table = root_table_name + SEPARATOR + str(version)
+                    versioned_root_table = versioned_root_table[:self.IDENTIFIER_FIELD_LENGTH]
 
                     names_to_paths = dict([(v, k) for k, v in self.table_mapping_cache.items()])
 

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -629,8 +629,6 @@ class PostgresTarget(SQLInterface):
     def write_table_batch(self, cur, table_batch, metadata):
         remote_schema = table_batch['remote_schema']
 
-        self.LOGGER.info(table_batch)
-
         ## Create temp table to upload new data to
         target_table_name = self.canonicalize_identifier('tmp_' + str(uuid.uuid4()))
         cur.execute(sql.SQL('''

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -629,6 +629,8 @@ class PostgresTarget(SQLInterface):
     def write_table_batch(self, cur, table_batch, metadata):
         remote_schema = table_batch['remote_schema']
 
+        self.LOGGER.info(table_batch)
+
         ## Create temp table to upload new data to
         target_table_name = self.canonicalize_identifier('tmp_' + str(uuid.uuid4()))
         cur.execute(sql.SQL('''

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -861,6 +861,7 @@ class SQLInterface:
                                 table_batch['streamed_schema']['path']
                             ))
 
+                            self.LOGGER.info(table_batch)
                             remote_schema = self.upsert_table_helper(connection,
                                                                      table_batch['streamed_schema'],
                                                                      metadata)

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -861,7 +861,6 @@ class SQLInterface:
                                 table_batch['streamed_schema']['path']
                             ))
 
-                            self.LOGGER.info(table_batch)
                             remote_schema = self.upsert_table_helper(connection,
                                                                      table_batch['streamed_schema'],
                                                                      metadata)

--- a/target_postgres/stream_tracker.py
+++ b/target_postgres/stream_tracker.py
@@ -64,6 +64,10 @@ class StreamTracker:
 
     def _write_batch_and_update_watermarks(self, stream):
         stream_buffer = self.streams[stream]
+        if len(stream_buffer.stream) >= self.target.IDENTIFIER_FIELD_LENGTH:
+            # separator length also included
+            max_length = self.target.IDENTIFIER_FIELD_LENGTH - 2 - len(str(stream_buffer.max_version))
+            stream_buffer.stream = stream_buffer.stream[:max_length]
         self.target.write_batch(stream_buffer)
         stream_buffer.flush_buffer()
         self.stream_flush_watermarks[stream] = self.stream_add_watermarks.get(stream, 0)


### PR DESCRIPTION
# Description
This PR fixes issues where tables with very long table names would cause duplicates to be created on every sync. 

## Reference Ticket
-  [Materialize creates duplicate tables __1, __2 etc.](https://www.notion.so/Materialize-creates-duplicate-tables-__1-__2-etc-1ba1aa9b3879809a8256e623a2361eba?pvs=4)

## Additional Notes
- For test scenarios 3 and 4 we will truncate the stream name. In other words, we will penalise names that exceed or are equal to  the limit. This should encourage users to choose a sensible table name.

## To Do
- Nothing.

## Downstream dependencies
- Nothing.

## Test Cases
- [x] Test duplicates are no longer created for tables with very long names
- [x] Test operation works as before for pipelines
- [x] Test operation works as before for tables with short names
- [x] Handle follwoing scenarios
    - [x] Scenario 1
        - Root table name is shorter than IDENTIFIER_FIELD_LENGTH
        - Versioned table name is shorted than IDENTIFIER_FIELD_LENGTH
        
    - [x] Scenario 2
        - Root table name is shorter than IDENTIFIER_FIELD_LENGTH
        - Versioned table name in longer than IDENTIFIER_FIELD_LENGTH
     
    - [x] Scenario 3
        - Root table name is longer than IDENTIFIER_FIELD_LENGTH
        - Versioned table name is longer than IDENTIFIER_FIELD_LENGTH
        
    - [x] Scenario 4
        - Root table name is equal to IDENTIFIER_FIELD_LENGTH
        - Versioned table name is longer than IDENTIFIER_FIELD_LENGTH

## Change Type
⬜  DevOps
⬜  New feature (non-breaking change which adds functionality)
✅  Bug fix (non-breaking change which fixes an issue)
⬜  Refactor
⬜  Breaking change (fix or feature that would cause existing functionality to not work as expected) 
⬜  This change requires a documentation update