### PR TITLE
[#19][Feat]Do a retry when psycopg2 throws a `connection has been closed unexpectedly` error message

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -392,7 +392,11 @@ class PostgresTarget(SQLInterface):
                         self.LOGGER.exception(message)
                         raise PostgresError(message, ex)
             except Exception as ex:
-                if 'connection already closed' not in str(ex) and 'cursor already closed' not in str(ex):
+                if (
+                        'connection already closed' not in str(ex) and
+                        'cursor already closed' not in str(ex) and
+                        'connection has been closed unexpectedly' not in str(ex)
+                ):
                     raise
 
                 exception = ex


### PR DESCRIPTION
# Description
This PR handles the case when the error message is `connection has been closed unexpectedly`

## Reference Ticket
- closes #19

## Additional Notes
- Nothing.

## To Do
- Nothing.

## Downstream dependencies
- Nothing.

## Test Cases
- [x] Test if the retry is triggered when error message matches the pattern.

## Change Type
⬜  DevOps
⬜  New feature (non-breaking change which adds functionality)
⬜  Bug fix (non-breaking change which fixes an issue)
✅  Refactor
⬜  Breaking change (fix or feature that would cause existing functionality to not work as expected) 
⬜  This change requires a documentation update