### PR TITLE
Fix: Execute view creation commands one by one and catch exception

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -660,34 +660,42 @@ class PostgresTarget(SQLInterface):
                                 f"{view_data}"
                             )
 
-                            cur.execute(
-                                sql.SQL(
-                                    '''
-                                    CREATE {object_type} {schema_name}.{view_name} AS {query} {check_option_fragment};
-                                    '''
-                                ).format(
-                                    object_type=sql.SQL(object_type),
-                                    schema_name=sql.Identifier(schema_name),
-                                    view_name=sql.Identifier(view_name),
-                                    query=sql.SQL(query),
-                                    check_option_fragment=sql.SQL(check_option_fragment),
+                            try:
+                                cur.execute(
+                                    sql.SQL(
+                                        '''
+                                        CREATE {object_type} {schema_name}.{view_name} AS {query} {check_option_fragment};
+                                        '''
+                                    ).format(
+                                        object_type=sql.SQL(object_type),
+                                        schema_name=sql.Identifier(schema_name),
+                                        view_name=sql.Identifier(view_name),
+                                        query=sql.SQL(query),
+                                        check_option_fragment=sql.SQL(check_option_fragment),
+                                    )
                                 )
-                            )
 
-                            cur.execute(
-                                sql.SQL(
-                                    '''
-                                    ALTER {object_type} {schema_name}.{view_name} OWNER TO {view_owner};
-                                    '''
-                                ).format(
-                                    object_type=sql.SQL(object_type),
-                                    schema_name=sql.Identifier(schema_name),
-                                    view_name=sql.Identifier(view_name),
-                                    view_owner=sql.Identifier(view_owner),
+                                cur.execute(
+                                    sql.SQL(
+                                        '''
+                                        ALTER {object_type} {schema_name}.{view_name} OWNER TO {view_owner};
+                                        '''
+                                    ).format(
+                                        object_type=sql.SQL(object_type),
+                                        schema_name=sql.Identifier(schema_name),
+                                        view_name=sql.Identifier(view_name),
+                                        view_owner=sql.Identifier(view_owner),
+                                    )
                                 )
-                            )
 
-                        cur.execute('COMMIT;')
+                                cur.execute('COMMIT;')
+                            except Exception as ex:
+                                cur.execute('ROLLBACK;')
+                                message = '{} - Exception re-creating view {}: {}'.format(
+                                    stream_buffer.stream,
+                                    view_name,
+                                    ex)
+                                self.LOGGER.exception(message)
 
                         metadata = self._get_table_metadata(cur, table_name)
 


### PR DESCRIPTION
## Problem:
- During creation of views, duplicate views might exist from the dependency graph, and this can cause view creation step to fail.
- This failure blocks the entire process during FULL RESYNC, as the whole view creation is in one transaction.

eg:
```
ERROR TARGET 2025-08-29 10:27:13,100 only_users - Exception activating table version 1756463230
Traceback (most recent call last):
  File "/etc/.virtualenvs/target-postgres/lib/python3.9/site-packages/target_postgres/postgres.py", line 663, in activate_version
    cur.execute(
  File "/etc/.virtualenvs/target-postgres/lib/python3.9/site-packages/target_postgres/postgres.py", line 90, in execute
    return super(_MillisLoggingCursor, self).execute(query, vars)
  File "/etc/.virtualenvs/target-postgres/lib/python3.9/site-packages/psycopg2/extras.py", line 445, in execute
    return super().execute(query, vars)
psycopg2.errors.DuplicateTable: relation "table_name" already exists

CRITICAL TARGET 2025-08-29 10:27:13,101 ('stream_name - Exception activating table version 1756463230', DuplicateTable('relation "table_name" already exists\n'))
Traceback (most recent call last):
  File "/etc/.virtualenvs/target-postgres/lib/python3.9/site-packages/target_postgres/postgres.py", line 663, in activate_version
    cur.execute(
  File "/etc/.virtualenvs/target-postgres/lib/python3.9/site-packages/target_postgres/postgres.py", line 90, in execute
    return super(_MillisLoggingCursor, self).execute(query, vars)
  File "/etc/.virtualenvs/target-postgres/lib/python3.9/site-packages/psycopg2/extras.py", line 445, in execute
    return super().execute(query, vars)
psycopg2.errors.DuplicateTable: relation "table_name" already exists
```

## Changes:
- Make the transaction commit after each view creation, to gracefully move to the next view.
- Log the error if any, without blocking the rest of the view creations.

