### PR TITLE
[Fix] Add transaction commit after _set_table_metadata in Activate version

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -465,7 +465,7 @@ class PostgresTarget(SQLInterface):
                             if stream_buffer.max_version < current_table_version:
                                 self.LOGGER.warning('{} - Records from an earlier table version detected.'
                                                     .format(stream_buffer.stream))
-                                cur.execute('ROLLBACK;')
+                                self.conn.rollback()
                                 return None
 
                             elif stream_buffer.max_version > current_table_version:
@@ -485,9 +485,9 @@ class PostgresTarget(SQLInterface):
 
                         return written_batches_details
                     except Exception as ex:
-                        cur.execute('ROLLBACK;')
                         message = 'Exception writing records'
                         self.LOGGER.exception(message)
+                        self.conn.rollback()
                         raise PostgresError(message, ex)
             except Exception as ex:
                 if (
@@ -1021,6 +1021,7 @@ class PostgresTarget(SQLInterface):
             sql.Identifier(self.postgres_schema),
             sql.Identifier(table_name),
             sql.Literal(json.dumps(metadata))))
+        cur.connection.commit()
 
     def _get_table_metadata(self, cur, table_name):
         cur.execute(sql.SQL('''


### PR DESCRIPTION
## Problem:

During FULL_TABLE syncs (Activate version), new versioned tables were getting created, but the original table was not getting updated with the new data.


## Root Cause:

The table comments (singer metadata) was not getting updated after the activate version block, and hence the table carried the comments with table_version in the `path`

eg, Invoices table had table comment like 
`{"path": ["Invoices__1761649503"], "version": 1761649503, "schema_version": 2, "key_p......`

But it should be
`{"path": ["Invoices"], "version": 1761649503, "schema_version": 2, "key_p......`


### Why this happened:
- In the first run Invoices table gets created, the `set_table_metadata` is called in `add_table()` function. Somewhere down the line it gets committed.
- Activate version is the last step after adding records, and `set_table_metadata` is called once again here. Since the code exits after this, and no **commit** is executed later, the new table has the commit with the version, which was originally created by the `add_table()` for that version.

## Solution:
- A **commit** inside the `set_table_metadata` function after setting the table comment will ensure that the commit is executed for sure, at each call of this function.

## Tests:
- Created tables with `FULL_TABLE` and ran multiple times with different versions.
- The tables get updated with the new data correctly.

## Post-Deploy
- For existing connections, which have this versioned table popping up, they either need to be Full resynced, or the table comment need to be fixed manually