### PR TITLE
[PQ-3545] [Feat]: handle DELETERECORD — PK-based row deletion

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -525,10 +525,13 @@ class PostgresTarget(SQLInterface):
         the target. Each item in `records` is a dict of {pk_column: value, ...};
         all key/value pairs are matched, so composite primary keys are supported.
 
-        Deletes are best-effort: a missing table, missing primary-key column or a
-        primary key that matches no rows is logged and skipped, never raised. This
-        mirrors the ticket requirement that the target must not error when a delete
-        cannot be applied (e.g. the row was already gone).
+        A delete that cannot be *applied* is best-effort and skipped (returns 0):
+        a missing table, a primary-key column absent from the table, or a key that
+        matches no rows -- the row may already be gone. Transient connection loss
+        is retried (reconnect + replay) up to MAX_RETRY_COUNT, mirroring
+        write_batch; any other execution failure, or exhausted retries, is raised
+        so the caller does not advance the delete bookmark past a deletion that was
+        never actually applied.
 
         :param stream_name: the stream (table) to delete from
         :param records: list of dicts mapping primary-key column name -> value
@@ -537,80 +540,113 @@ class PostgresTarget(SQLInterface):
         if not records:
             return 0
 
-        deleted_total = 0
-        with self.conn.cursor() as cur:
+        # Mirror write_batch's connection-retry loop: a transient connection loss
+        # is retried (reconnect + replay) up to MAX_RETRY_COUNT; any other failure
+        # is raised. A delete that simply cannot be applied (missing table/column,
+        # no matching rows) is still a best-effort skip (return 0) -- the row may
+        # already be gone -- but a real execution failure must never be swallowed,
+        # or the delete bookmark would advance past a deletion that never landed.
+        retry_counter = MAX_RETRY_COUNT
+        exception = None
+        while retry_counter >= 0:
             try:
-                cur.execute('BEGIN;')
+                with self.conn.cursor() as cur:
+                    try:
+                        cur.execute('BEGIN;')
 
-                self.setup_table_mapping_cache(cur)
-                root_table_name = self.add_table_mapping_helper(
-                    (stream_name,), self.table_mapping_cache
-                )['to']
-                current_table_schema = self.get_table_schema(cur, root_table_name)
+                        self.setup_table_mapping_cache(cur)
+                        root_table_name = self.add_table_mapping_helper(
+                            (stream_name,), self.table_mapping_cache
+                        )['to']
+                        current_table_schema = self.get_table_schema(cur, root_table_name)
 
-                if not current_table_schema:
-                    self.LOGGER.warning(
-                        'delete_records: table for stream `{}` does not exist; '
-                        'skipping {} delete(s)'.format(stream_name, len(records))
-                    )
-                    self.conn.rollback()
-                    return 0
+                        if not current_table_schema:
+                            self.LOGGER.warning(
+                                'delete_records: table for stream `{}` does not exist; '
+                                'skipping {} delete(s)'.format(stream_name, len(records))
+                            )
+                            self.conn.rollback()
+                            return 0
 
-                existing_columns = set(current_table_schema['schema']['properties'].keys())
+                        existing_columns = set(current_table_schema['schema']['properties'].keys())
 
-                # Primary-key columns come from the records themselves (the tap maps
-                # the source PK fields to target column names before emitting).
-                pk_columns = list(records[0].keys())
-                missing = [c for c in pk_columns if c not in existing_columns]
-                if not pk_columns or missing:
-                    self.LOGGER.warning(
-                        'delete_records: primary-key column(s) {} not found in '
-                        'table `{}`; skipping {} delete(s)'.format(
-                            missing or pk_columns, root_table_name, len(records)
+                        # Primary-key columns come from the records themselves (the tap maps
+                        # the source PK fields to target column names before emitting).
+                        pk_columns = list(records[0].keys())
+                        missing = [c for c in pk_columns if c not in existing_columns]
+                        if not pk_columns or missing:
+                            self.LOGGER.warning(
+                                'delete_records: primary-key column(s) {} not found in '
+                                'table `{}`; skipping {} delete(s)'.format(
+                                    missing or pk_columns, root_table_name, len(records)
+                                )
+                            )
+                            self.conn.rollback()
+                            return 0
+
+                        full_table = sql.SQL('{}.{}').format(
+                            sql.Identifier(self.postgres_schema),
+                            sql.Identifier(root_table_name),
                         )
-                    )
-                    self.conn.rollback()
-                    return 0
+                        columns_sql = sql.SQL(', ').join(sql.Identifier(c) for c in pk_columns)
 
-                full_table = sql.SQL('{}.{}').format(
-                    sql.Identifier(self.postgres_schema),
-                    sql.Identifier(root_table_name),
-                )
-                columns_sql = sql.SQL(', ').join(sql.Identifier(c) for c in pk_columns)
+                        # Batch the deletes: DELETE ... WHERE (pk1, pk2) IN ((..),(..),...)
+                        deleted_total = 0
+                        for start in range(0, len(records), self.DELETE_BATCH_SIZE):
+                            batch = records[start:start + self.DELETE_BATCH_SIZE]
+                            row_placeholders = sql.SQL(', ').join(
+                                sql.SQL('({})').format(
+                                    sql.SQL(', ').join(sql.Placeholder() for _ in pk_columns)
+                                )
+                                for _ in batch
+                            )
+                            delete_stmt = sql.SQL(
+                                'DELETE FROM {table} WHERE ({columns}) IN ({rows})'
+                            ).format(table=full_table, columns=columns_sql, rows=row_placeholders)
+                            params = [record[c] for record in batch for c in pk_columns]
+                            cur.execute(delete_stmt, params)
+                            deleted_total += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
 
-                # Batch the deletes: DELETE ... WHERE (pk1, pk2) IN ((..),(..),...)
-                for start in range(0, len(records), self.DELETE_BATCH_SIZE):
-                    batch = records[start:start + self.DELETE_BATCH_SIZE]
-                    row_placeholders = sql.SQL(', ').join(
-                        sql.SQL('({})').format(
-                            sql.SQL(', ').join(sql.Placeholder() for _ in pk_columns)
+                        self.conn.commit()
+                        self.LOGGER.info(
+                            'delete_records: deleted {} row(s) from `{}` ({} delete(s) requested)'.format(
+                                deleted_total, root_table_name, len(records)
+                            )
                         )
-                        for _ in batch
-                    )
-                    delete_stmt = sql.SQL(
-                        'DELETE FROM {table} WHERE ({columns}) IN ({rows})'
-                    ).format(table=full_table, columns=columns_sql, rows=row_placeholders)
-                    params = [record[c] for record in batch for c in pk_columns]
-                    cur.execute(delete_stmt, params)
-                    deleted_total += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
-
-                self.conn.commit()
-                self.LOGGER.info(
-                    'delete_records: deleted {} row(s) from `{}` ({} delete(s) requested)'.format(
-                        deleted_total, root_table_name, len(records)
-                    )
-                )
-                return deleted_total
+                        return deleted_total
+                    except Exception as ex:
+                        # The DELETE itself failed (this is not a deterministic skip,
+                        # those return above). Roll back and re-raise so the retry
+                        # layer below can reconnect on transient loss or surface the
+                        # error -- a genuine failure must never be swallowed.
+                        message = 'Exception deleting records'
+                        self.LOGGER.exception(message)
+                        self.conn.rollback()
+                        raise PostgresError(message, ex)
             except Exception as ex:
-                # Best-effort: never raise on a failed delete, just log and roll back.
-                self.LOGGER.warning(
-                    'delete_records: failed to delete from stream `{}`: {}'.format(stream_name, ex)
-                )
+                if (
+                        'connection already closed' not in str(ex) and
+                        'cursor already closed' not in str(ex) and
+                        'connection has been closed unexpectedly' not in str(ex)
+                ):
+                    raise
+
+                exception = ex
+                if retry_counter <= 0:
+                    break
+
+                self.LOGGER.warning('Connection error: {}. Attempting to reconnect'.format(ex))
                 try:
-                    self.conn.rollback()
+                    # make sure old connection is actually closed
+                    self.conn.close()
                 except Exception:
                     pass
-                return 0
+
+                self.conn = self._get_connection()
+                self.LOGGER.info('Re-processing delete batch Attempt({})'.format(MAX_RETRY_COUNT - retry_counter + 1))
+                retry_counter -= 1
+
+        raise PostgresError(f"Retry limit exceeded while deleting records from Postgres error={exception}. Exiting...")
 
     def activate_version(self, stream_buffer, version):
         with self.conn.cursor() as cur:

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -124,6 +124,9 @@ class PostgresTarget(SQLInterface):
     # TODO: Figure out way to `SELECT` value from commands
     IDENTIFIER_FIELD_LENGTH = 63
 
+    ## Max number of DELETERECORD rows deleted per DELETE statement (per stream).
+    DELETE_BATCH_SIZE = 1000
+
     def __init__(self, config, *args,
         postgres_schema='public',
         logging_level=None,
@@ -514,6 +517,100 @@ class PostgresTarget(SQLInterface):
 
 
         raise PostgresError(f"Retry limit exceeded while writing batch to Postgres error={exception}. Exiting...")
+
+    def delete_records(self, stream_name, records):
+        """Delete rows from a stream's table by primary key.
+
+        Used to propagate source-side deletions (Singer DELETERECORD messages) to
+        the target. Each item in `records` is a dict of {pk_column: value, ...};
+        all key/value pairs are matched, so composite primary keys are supported.
+
+        Deletes are best-effort: a missing table, missing primary-key column or a
+        primary key that matches no rows is logged and skipped, never raised. This
+        mirrors the ticket requirement that the target must not error when a delete
+        cannot be applied (e.g. the row was already gone).
+
+        :param stream_name: the stream (table) to delete from
+        :param records: list of dicts mapping primary-key column name -> value
+        :return: number of rows deleted
+        """
+        if not records:
+            return 0
+
+        deleted_total = 0
+        with self.conn.cursor() as cur:
+            try:
+                cur.execute('BEGIN;')
+
+                self.setup_table_mapping_cache(cur)
+                root_table_name = self.add_table_mapping_helper(
+                    (stream_name,), self.table_mapping_cache
+                )['to']
+                current_table_schema = self.get_table_schema(cur, root_table_name)
+
+                if not current_table_schema:
+                    self.LOGGER.warning(
+                        'delete_records: table for stream `{}` does not exist; '
+                        'skipping {} delete(s)'.format(stream_name, len(records))
+                    )
+                    self.conn.rollback()
+                    return 0
+
+                existing_columns = set(current_table_schema['schema']['properties'].keys())
+
+                # Primary-key columns come from the records themselves (the tap maps
+                # the source PK fields to target column names before emitting).
+                pk_columns = list(records[0].keys())
+                missing = [c for c in pk_columns if c not in existing_columns]
+                if not pk_columns or missing:
+                    self.LOGGER.warning(
+                        'delete_records: primary-key column(s) {} not found in '
+                        'table `{}`; skipping {} delete(s)'.format(
+                            missing or pk_columns, root_table_name, len(records)
+                        )
+                    )
+                    self.conn.rollback()
+                    return 0
+
+                full_table = sql.SQL('{}.{}').format(
+                    sql.Identifier(self.postgres_schema),
+                    sql.Identifier(root_table_name),
+                )
+                columns_sql = sql.SQL(', ').join(sql.Identifier(c) for c in pk_columns)
+
+                # Batch the deletes: DELETE ... WHERE (pk1, pk2) IN ((..),(..),...)
+                for start in range(0, len(records), self.DELETE_BATCH_SIZE):
+                    batch = records[start:start + self.DELETE_BATCH_SIZE]
+                    row_placeholders = sql.SQL(', ').join(
+                        sql.SQL('({})').format(
+                            sql.SQL(', ').join(sql.Placeholder() for _ in pk_columns)
+                        )
+                        for _ in batch
+                    )
+                    delete_stmt = sql.SQL(
+                        'DELETE FROM {table} WHERE ({columns}) IN ({rows})'
+                    ).format(table=full_table, columns=columns_sql, rows=row_placeholders)
+                    params = [record[c] for record in batch for c in pk_columns]
+                    cur.execute(delete_stmt, params)
+                    deleted_total += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+
+                self.conn.commit()
+                self.LOGGER.info(
+                    'delete_records: deleted {} row(s) from `{}` ({} delete(s) requested)'.format(
+                        deleted_total, root_table_name, len(records)
+                    )
+                )
+                return deleted_total
+            except Exception as ex:
+                # Best-effort: never raise on a failed delete, just log and roll back.
+                self.LOGGER.warning(
+                    'delete_records: failed to delete from stream `{}`: {}'.format(stream_name, ex)
+                )
+                try:
+                    self.conn.rollback()
+                except Exception:
+                    pass
+                return 0
 
     def activate_version(self, stream_buffer, version):
         with self.conn.cursor() as cur:

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -524,6 +524,9 @@ class PostgresTarget(SQLInterface):
         Used to propagate source-side deletions (Singer DELETERECORD messages) to
         the target. Each item in `records` is a dict of {pk_column: value, ...};
         all key/value pairs are matched, so composite primary keys are supported.
+        Keys are canonicalized to physical column names the same way the write
+        path canonicalizes columns, so source-cased keys (e.g. `ID`) match the
+        stored column (`id`).
 
         A delete that cannot be *applied* is best-effort and skipped (returns 0):
         a missing table, a primary-key column absent from the table, or a key that
@@ -570,15 +573,20 @@ class PostgresTarget(SQLInterface):
 
                         existing_columns = set(current_table_schema['schema']['properties'].keys())
 
-                        # Primary-key columns come from the records themselves (the tap maps
-                        # the source PK fields to target column names before emitting).
-                        pk_columns = list(records[0].keys())
+                        # Delete keys arrive as the source field names, but the write
+                        # path stores them under canonicalized physical column names
+                        # (lower-cased, invalid chars -> `_`; see canonicalize_identifier).
+                        # Canonicalize the delete keys the same way so e.g. a connector
+                        # emitting `ID` matches the physical `id` column instead of
+                        # silently no-op'ing (and then advancing the delete bookmark).
+                        raw_pk_columns = list(records[0].keys())
+                        pk_columns = [self.canonicalize_identifier(c) for c in raw_pk_columns]
                         missing = [c for c in pk_columns if c not in existing_columns]
                         if not pk_columns or missing:
                             self.LOGGER.warning(
-                                'delete_records: primary-key column(s) {} not found in '
-                                'table `{}`; skipping {} delete(s)'.format(
-                                    missing or pk_columns, root_table_name, len(records)
+                                'delete_records: primary-key column(s) {} (canonicalized '
+                                'from {}) not found in table `{}`; skipping {} delete(s)'.format(
+                                    missing or pk_columns, raw_pk_columns, root_table_name, len(records)
                                 )
                             )
                             self.conn.rollback()
@@ -603,7 +611,9 @@ class PostgresTarget(SQLInterface):
                             delete_stmt = sql.SQL(
                                 'DELETE FROM {table} WHERE ({columns}) IN ({rows})'
                             ).format(table=full_table, columns=columns_sql, rows=row_placeholders)
-                            params = [record[c] for record in batch for c in pk_columns]
+                            # WHERE columns use canonical names (pk_columns); the values
+                            # are read from each record by its raw (source) key.
+                            params = [record[c] for record in batch for c in raw_pk_columns]
                             cur.execute(delete_stmt, params)
                             deleted_total += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
 

--- a/target_postgres/stream_tracker.py
+++ b/target_postgres/stream_tracker.py
@@ -1,9 +1,14 @@
 from collections import deque
 import json
+import singer
 import singer.statediff as statediff
 import sys
 
 from target_postgres.exceptions import TargetError
+
+LOGGER = singer.get_logger(is_target=True)
+
+DEFAULT_DELETE_BATCH_SIZE = 1000
 
 
 class StreamTracker:
@@ -33,18 +38,35 @@ class StreamTracker:
         self.message_counter = 0
         self.last_emitted_state = None
 
+        # dict of {'<stream_name>': [pk_record, ...]} buffering DELETERECORD messages
+        # until they are flushed to the target. A stream may appear here without a
+        # corresponding BufferedSingerStream, since a delete can target a table that
+        # was not (re)synced in this run (e.g. a dedicated delete-sync run).
+        self.delete_buffers = {}
+
     def register_stream(self, stream, buffered_stream):
         self.streams[stream] = buffered_stream
         self.stream_flush_watermarks[stream] = 0
 
     def flush_stream(self, stream):
-        self._write_batch_and_update_watermarks(stream)
+        if stream in self.streams:
+            self._write_batch_and_update_watermarks(stream)
+        # Flush deletes after records so an upsert + delete of the same PK in the
+        # same run ends up deleted.
+        if stream in self.delete_buffers:
+            self._flush_deletes(stream)
         self._emit_safe_queued_states()
 
     def flush_streams(self, force=False):
         for (stream, stream_buffer) in self.streams.items():
             if force or stream_buffer.buffer_full:
                 self._write_batch_and_update_watermarks(stream)
+
+        # Flush delete buffers after record batches (same ordering rationale as above).
+        delete_batch_size = getattr(self.target, 'DELETE_BATCH_SIZE', DEFAULT_DELETE_BATCH_SIZE)
+        for stream in list(self.delete_buffers.keys()):
+            if force or len(self.delete_buffers[stream]) >= delete_batch_size:
+                self._flush_deletes(stream)
 
         self._emit_safe_queued_states(force=force)
 
@@ -62,6 +84,21 @@ class StreamTracker:
         self.stream_add_watermarks[stream] = self.message_counter
         self.streams[stream].add_record_message(line_data)
 
+    def handle_delete_record_message(self, stream, record):
+        """Buffer a DELETERECORD's primary-key map for later deletion in the target.
+
+        Unlike RECORD messages, a DELETERECORD does not require a prior SCHEMA: a
+        delete can target a table that was not (re)synced in this run. The buffered
+        deletes are flushed (and STATE held back) using the same watermark logic as
+        record batches.
+        """
+        self.message_counter += 1
+        self.streams_added_to.add(stream)
+        self.stream_add_watermarks[stream] = self.message_counter
+        if stream not in self.stream_flush_watermarks:
+            self.stream_flush_watermarks[stream] = 0
+        self.delete_buffers.setdefault(stream, []).append(record)
+
     def _write_batch_and_update_watermarks(self, stream):
         stream_buffer = self.streams[stream]
         if len(stream_buffer.stream) >= self.target.IDENTIFIER_FIELD_LENGTH:
@@ -71,6 +108,20 @@ class StreamTracker:
         self.target.write_batch(stream_buffer)
         stream_buffer.flush_buffer()
         self.stream_flush_watermarks[stream] = self.stream_add_watermarks.get(stream, 0)
+
+    def _flush_deletes(self, stream):
+        records = self.delete_buffers.pop(stream, [])
+        if records:
+            if hasattr(self.target, 'delete_records'):
+                self.target.delete_records(stream, records)
+            else:
+                LOGGER.warning(
+                    "Target does not implement delete_records; "
+                    "skipping {} delete(s) for stream {}".format(len(records), stream)
+                )
+        self.stream_flush_watermarks[stream] = self.stream_add_watermarks.get(
+            stream, self.stream_flush_watermarks.get(stream, 0)
+        )
 
     def _emit_safe_queued_states(self, force=False):
         # State messages that occured before the least recently flushed record are safe to emit.

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -140,6 +140,15 @@ def _line_handler(state_tracker, target, invalid_records_detect, invalid_records
 
         line_data[RAW_LINE_SIZE] = len(line)
         state_tracker.handle_record_message(line_data['stream'], line_data)
+    elif line_data['type'] == 'DELETERECORD':
+        # Source-side deletion: delete the row(s) matching the primary-key map in
+        # `record`. Unlike RECORD, no prior SCHEMA is required (a delete can target
+        # a table that was not (re)synced this run).
+        if 'stream' not in line_data:
+            raise TargetError('`stream` is a required key: {}'.format(line))
+        if 'record' not in line_data:
+            raise TargetError('`record` is a required key: {}'.format(line))
+        state_tracker.handle_delete_record_message(line_data['stream'], line_data['record'])
     elif line_data['type'] == 'ACTIVATE_VERSION':
         if 'stream' not in line_data:
             raise TargetError('`stream` is a required key: {}'.format(line))

--- a/tests/unit/test_delete_record_routing.py
+++ b/tests/unit/test_delete_record_routing.py
@@ -1,0 +1,130 @@
+"""
+Unit tests for DELETERECORD routing through target_tools / StreamTracker.
+
+These verify that a DELETERECORD Singer message is buffered and dispatched to the
+target's delete_records(), that record batches are flushed before deletes (so an
+upsert + delete of the same PK ends up deleted), that deletes for un-synced
+streams are still routed, and that a malformed DELETERECORD raises.
+
+No live Postgres needed: a fake target records the calls it receives.
+"""
+import json
+
+import pytest
+
+from target_postgres import target_tools
+
+
+class FakeTarget:
+    IDENTIFIER_FIELD_LENGTH = 63
+    DELETE_BATCH_SIZE = 1000
+
+    def __init__(self):
+        self.calls = []
+
+    def write_batch(self, stream_buffer):
+        self.calls.append(("write_batch", stream_buffer.stream, stream_buffer.count))
+        return None
+
+    def activate_version(self, stream_buffer, version):
+        self.calls.append(("activate_version", stream_buffer.stream, version))
+        return None
+
+    def delete_records(self, stream, records):
+        self.calls.append(("delete_records", stream, [dict(r) for r in records]))
+        return len(records)
+
+
+SCHEMA = {
+    "type": "SCHEMA",
+    "stream": "accounts",
+    "schema": {"type": "object", "properties": {"id": {"type": ["integer"]}}},
+    "key_properties": ["id"],
+}
+
+CONFIG = {"disable_collection": True}
+
+
+def _line(d):
+    return json.dumps(d)
+
+
+def _delete_calls(target):
+    return [c for c in target.calls if c[0] == "delete_records"]
+
+
+# WHY: core contract — a DELETERECORD reaches the target as delete_records(stream, [pk]).
+def test_delete_record_routed_to_delete_records():
+    target = FakeTarget()
+    lines = [
+        _line(SCHEMA),
+        _line({"type": "RECORD", "stream": "accounts", "record": {"id": 1}}),
+        _line({"type": "DELETERECORD", "stream": "accounts", "record": {"id": 2}}),
+    ]
+
+    target_tools.stream_to_target(lines, target, config=CONFIG)
+
+    assert _delete_calls(target) == [("delete_records", "accounts", [{"id": 2}])]
+
+
+# WHY: record batches must flush before deletes so insert+delete of the same PK
+#      in one run results in the row being deleted.
+def test_records_flushed_before_deletes():
+    target = FakeTarget()
+    lines = [
+        _line(SCHEMA),
+        _line({"type": "RECORD", "stream": "accounts", "record": {"id": 1}}),
+        _line({"type": "DELETERECORD", "stream": "accounts", "record": {"id": 1}}),
+    ]
+
+    target_tools.stream_to_target(lines, target, config=CONFIG)
+
+    kinds = [c[0] for c in target.calls]
+    assert kinds.index("write_batch") < kinds.index("delete_records")
+
+
+# WHY: a delete can target a table that had no SCHEMA/RECORD this run (e.g. a
+#      dedicated delete-sync run) and must still be routed.
+def test_delete_for_unsynced_stream_is_routed():
+    target = FakeTarget()
+    lines = [
+        _line({"type": "DELETERECORD", "stream": "ghost", "record": {"id": 9}}),
+    ]
+
+    target_tools.stream_to_target(lines, target, config=CONFIG)
+
+    assert ("delete_records", "ghost", [{"id": 9}]) in target.calls
+
+
+# WHY: multiple deletes for a stream are batched into a single delete_records call.
+def test_multiple_deletes_batched_per_stream():
+    target = FakeTarget()
+    lines = [
+        _line({"type": "DELETERECORD", "stream": "accounts", "record": {"id": 1}}),
+        _line({"type": "DELETERECORD", "stream": "accounts", "record": {"id": 2}}),
+        _line({"type": "DELETERECORD", "stream": "accounts", "record": {"id": 3}}),
+    ]
+
+    target_tools.stream_to_target(lines, target, config=CONFIG)
+
+    assert _delete_calls(target) == [
+        ("delete_records", "accounts", [{"id": 1}, {"id": 2}, {"id": 3}])
+    ]
+
+
+# WHY: a DELETERECORD without a `record` is malformed and must raise.
+def test_delete_record_missing_record_raises():
+    target = FakeTarget()
+    lines = [_line({"type": "DELETERECORD", "stream": "accounts"})]
+
+    with pytest.raises(Exception):
+        target_tools.stream_to_target(lines, target, config=CONFIG)
+
+
+# WHY: a DELETERECORD without a `stream` is malformed and must raise.
+def test_delete_record_missing_stream_raises():
+    target = FakeTarget()
+    lines = [_line({"type": "DELETERECORD", "record": {"id": 1}})]
+
+    with pytest.raises(Exception):
+        target_tools.stream_to_target(lines, target, config=CONFIG)

--- a/tests/unit/test_postgres_delete_records.py
+++ b/tests/unit/test_postgres_delete_records.py
@@ -67,7 +67,7 @@ class FakeConn:
         self.closed = True
 
 
-def _make_target(cur, schema_props=("ID",)):
+def _make_target(cur, schema_props=("id",)):
     """Build a PostgresTarget without running __init__ (which would connect to PG)."""
     target = PostgresTarget.__new__(PostgresTarget)
     target.conn = FakeConn(cur)
@@ -86,9 +86,10 @@ def _make_target(cur, schema_props=("ID",)):
 
 
 # WHY: happy path — a single batch deletes by PK, commits, returns rowcount.
+#      (The source key "ID" is canonicalized to the physical column "id".)
 def test_deletes_by_single_pk_and_commits():
     cur = FakeCursor(rowcounts=[2])
-    target = _make_target(cur, schema_props=("ID",))
+    target = _make_target(cur, schema_props=("id",))
 
     deleted = target.delete_records("Accounts", [{"ID": "a1"}, {"ID": "a2"}])
 
@@ -97,11 +98,35 @@ def test_deletes_by_single_pk_and_commits():
     assert cur.delete_params() == [["a1", "a2"]]
 
 
+# WHY (#4): source-cased keys must canonicalize to the physical column name. The
+#      write path stores `ID` as `id`; a raw match would no-op silently.
+def test_delete_key_is_canonicalized_to_physical_column():
+    cur = FakeCursor(rowcounts=[1])
+    target = _make_target(cur, schema_props=("id",))
+
+    deleted = target.delete_records("Accounts", [{"ID": "a1"}])
+
+    assert deleted == 1
+    assert cur.delete_params() == [["a1"]]
+
+
+# WHY (#4): canonicalization also replaces invalid identifier chars (space ->
+#      `_`), matching how the column was created on write.
+def test_delete_key_with_invalid_chars_canonicalized():
+    cur = FakeCursor(rowcounts=[1])
+    target = _make_target(cur, schema_props=("account_id",))
+
+    deleted = target.delete_records("Accounts", [{"Account Id": "a1"}])
+
+    assert deleted == 1
+    assert cur.delete_params() == [["a1"]]
+
+
 # WHY: composite PKs must flatten params as (v1a, v2a, v1b, v2b, ...) matching
 #      the WHERE (col1, col2) IN (...) tuple ordering.
 def test_deletes_by_composite_pk():
     cur = FakeCursor(rowcounts=[1])
-    target = _make_target(cur, schema_props=("ID", "_sdc_division"))
+    target = _make_target(cur, schema_props=("id", "_sdc_division"))
 
     deleted = target.delete_records(
         "Journals", [{"ID": "g1", "_sdc_division": 100}]
@@ -114,7 +139,7 @@ def test_deletes_by_composite_pk():
 # WHY: large delete sets are split into DELETE_BATCH_SIZE-sized statements.
 def test_batches_deletes():
     cur = FakeCursor(rowcounts=[2, 2, 1])
-    target = _make_target(cur, schema_props=("ID",))
+    target = _make_target(cur, schema_props=("id",))
     target.DELETE_BATCH_SIZE = 2
 
     records = [{"ID": f"a{i}"} for i in range(5)]
@@ -152,7 +177,7 @@ def test_missing_table_is_skipped():
 # WHY: a PK column absent from the table -> skip + rollback, never raise.
 def test_missing_pk_column_is_skipped():
     cur = FakeCursor()
-    target = _make_target(cur, schema_props=("OTHER",))
+    target = _make_target(cur, schema_props=("other",))
 
     deleted = target.delete_records("Accounts", [{"ID": "x"}])
 
@@ -166,7 +191,7 @@ def test_missing_pk_column_is_skipped():
 #      delete bookmark past a deletion that never landed (data loss).
 def test_execute_failure_raises():
     cur = FakeCursor(raise_on_delete=True)  # generic, non-connection error
-    target = _make_target(cur, schema_props=("ID",))
+    target = _make_target(cur, schema_props=("id",))
     # A non-connection error must NOT trigger a reconnect.
     reconnects = {"n": 0}
     target._get_connection = lambda *a, **k: reconnects.__setitem__("n", reconnects["n"] + 1)
@@ -183,7 +208,7 @@ def test_execute_failure_raises():
 #      silent success.
 def test_connection_loss_retries_then_raises():
     cur0 = FakeCursor(raise_on_delete="connection already closed")
-    target = _make_target(cur0, schema_props=("ID",))
+    target = _make_target(cur0, schema_props=("id",))
 
     reconnects = {"n": 0}
 
@@ -205,7 +230,7 @@ def test_connection_loss_retries_then_raises():
 def test_connection_loss_then_recovers():
     cur0 = FakeCursor(raise_on_delete="connection already closed")
     good_cur = FakeCursor(rowcounts=[1])
-    target = _make_target(cur0, schema_props=("ID",))
+    target = _make_target(cur0, schema_props=("id",))
 
     reconnects = {"n": 0}
 

--- a/tests/unit/test_postgres_delete_records.py
+++ b/tests/unit/test_postgres_delete_records.py
@@ -8,7 +8,8 @@ test_postgres.py covers end-to-end behavior).
 """
 import pytest
 
-from target_postgres.postgres import PostgresTarget
+from target_postgres.postgres import PostgresTarget, MAX_RETRY_COUNT
+from target_postgres.exceptions import PostgresError
 
 
 class FakeCursor:
@@ -31,7 +32,14 @@ class FakeCursor:
             return
         # Composed DELETE statement
         if self.raise_on_delete:
-            raise Exception("simulated execute failure")
+            # raise_on_delete may be a custom message (e.g. to simulate a
+            # transient 'connection already closed' error) or just True.
+            msg = (
+                self.raise_on_delete
+                if isinstance(self.raise_on_delete, str)
+                else "simulated execute failure"
+            )
+            raise Exception(msg)
         self.executed.append((stmt, params))
         self.rowcount = self._rowcounts.pop(0) if self._rowcounts else 0
 
@@ -44,6 +52,7 @@ class FakeConn:
         self._cur = cur
         self.committed = False
         self.rolled_back = False
+        self.closed = False
 
     def cursor(self):
         return self._cur
@@ -53,6 +62,9 @@ class FakeConn:
 
     def rollback(self):
         self.rolled_back = True
+
+    def close(self):
+        self.closed = True
 
 
 def _make_target(cur, schema_props=("ID",)):
@@ -149,13 +161,62 @@ def test_missing_pk_column_is_skipped():
     assert target.conn.rolled_back is True
 
 
-# WHY: a failure executing the DELETE is best-effort — rolled back, returns 0,
-#      and must NOT propagate (per the ticket: deletes never error the run).
-def test_execute_failure_is_swallowed():
-    cur = FakeCursor(raise_on_delete=True)
+# WHY: a real DELETE execution failure (not a deterministic skip) must be
+#      RAISED, not swallowed. Swallowing it would let the caller advance the
+#      delete bookmark past a deletion that never landed (data loss).
+def test_execute_failure_raises():
+    cur = FakeCursor(raise_on_delete=True)  # generic, non-connection error
     target = _make_target(cur, schema_props=("ID",))
+    # A non-connection error must NOT trigger a reconnect.
+    reconnects = {"n": 0}
+    target._get_connection = lambda *a, **k: reconnects.__setitem__("n", reconnects["n"] + 1)
+
+    with pytest.raises(PostgresError):
+        target.delete_records("Accounts", [{"ID": "x"}])
+
+    assert target.conn.rolled_back is True
+    assert reconnects["n"] == 0
+
+
+# WHY: a transient connection loss is retried (reconnect + replay) like
+#      write_batch, then RAISED once MAX_RETRY_COUNT is exhausted — never a
+#      silent success.
+def test_connection_loss_retries_then_raises():
+    cur0 = FakeCursor(raise_on_delete="connection already closed")
+    target = _make_target(cur0, schema_props=("ID",))
+
+    reconnects = {"n": 0}
+
+    def fake_get_connection(*a, **k):
+        reconnects["n"] += 1
+        # every reconnect also fails the same transient way
+        return FakeConn(FakeCursor(raise_on_delete="connection already closed"))
+
+    target._get_connection = fake_get_connection
+
+    with pytest.raises(PostgresError):
+        target.delete_records("Accounts", [{"ID": "x"}])
+
+    assert reconnects["n"] == MAX_RETRY_COUNT
+
+
+# WHY: a single transient connection loss recovers on reconnect and the delete
+#      still succeeds.
+def test_connection_loss_then_recovers():
+    cur0 = FakeCursor(raise_on_delete="connection already closed")
+    good_cur = FakeCursor(rowcounts=[1])
+    target = _make_target(cur0, schema_props=("ID",))
+
+    reconnects = {"n": 0}
+
+    def fake_get_connection(*a, **k):
+        reconnects["n"] += 1
+        return FakeConn(good_cur)
+
+    target._get_connection = fake_get_connection
 
     deleted = target.delete_records("Accounts", [{"ID": "x"}])
 
-    assert deleted == 0
-    assert target.conn.rolled_back is True
+    assert deleted == 1
+    assert reconnects["n"] == 1
+    assert good_cur.delete_params() == [["x"]]

--- a/tests/unit/test_postgres_delete_records.py
+++ b/tests/unit/test_postgres_delete_records.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for PostgresTarget.delete_records().
+
+These exercise the SQL-building, batching and best-effort error handling of the
+DELETERECORD delete path without a live Postgres: the cursor/connection and the
+table/schema lookups are faked, so the test runs anywhere (the live-DB suite in
+test_postgres.py covers end-to-end behavior).
+"""
+import pytest
+
+from target_postgres.postgres import PostgresTarget
+
+
+class FakeCursor:
+    def __init__(self, rowcounts=None, raise_on_delete=False):
+        # list of (stmt, params); BEGIN; is a plain string, DELETE is a Composable
+        self.executed = []
+        self._rowcounts = list(rowcounts or [])
+        self.rowcount = 0
+        self.raise_on_delete = raise_on_delete
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, stmt, params=None):
+        if isinstance(stmt, str):  # e.g. 'BEGIN;'
+            self.executed.append((stmt, params))
+            return
+        # Composed DELETE statement
+        if self.raise_on_delete:
+            raise Exception("simulated execute failure")
+        self.executed.append((stmt, params))
+        self.rowcount = self._rowcounts.pop(0) if self._rowcounts else 0
+
+    def delete_params(self):
+        return [params for (stmt, params) in self.executed if not isinstance(stmt, str)]
+
+
+class FakeConn:
+    def __init__(self, cur):
+        self._cur = cur
+        self.committed = False
+        self.rolled_back = False
+
+    def cursor(self):
+        return self._cur
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+
+def _make_target(cur, schema_props=("ID",)):
+    """Build a PostgresTarget without running __init__ (which would connect to PG)."""
+    target = PostgresTarget.__new__(PostgresTarget)
+    target.conn = FakeConn(cur)
+    target.postgres_schema = "public"
+    target.table_mapping_cache = {}
+    # Stub the DB-touching helpers so the test needs no live Postgres.
+    target.setup_table_mapping_cache = lambda c: None
+    target.add_table_mapping_helper = lambda path, cache: {"to": path[0]}
+    if schema_props is None:
+        target.get_table_schema = lambda c, name: None
+    else:
+        target.get_table_schema = lambda c, name: {
+            "schema": {"properties": {col: {} for col in schema_props}}
+        }
+    return target
+
+
+# WHY: happy path — a single batch deletes by PK, commits, returns rowcount.
+def test_deletes_by_single_pk_and_commits():
+    cur = FakeCursor(rowcounts=[2])
+    target = _make_target(cur, schema_props=("ID",))
+
+    deleted = target.delete_records("Accounts", [{"ID": "a1"}, {"ID": "a2"}])
+
+    assert deleted == 2
+    assert target.conn.committed is True
+    assert cur.delete_params() == [["a1", "a2"]]
+
+
+# WHY: composite PKs must flatten params as (v1a, v2a, v1b, v2b, ...) matching
+#      the WHERE (col1, col2) IN (...) tuple ordering.
+def test_deletes_by_composite_pk():
+    cur = FakeCursor(rowcounts=[1])
+    target = _make_target(cur, schema_props=("ID", "_sdc_division"))
+
+    deleted = target.delete_records(
+        "Journals", [{"ID": "g1", "_sdc_division": 100}]
+    )
+
+    assert deleted == 1
+    assert cur.delete_params() == [["g1", 100]]
+
+
+# WHY: large delete sets are split into DELETE_BATCH_SIZE-sized statements.
+def test_batches_deletes():
+    cur = FakeCursor(rowcounts=[2, 2, 1])
+    target = _make_target(cur, schema_props=("ID",))
+    target.DELETE_BATCH_SIZE = 2
+
+    records = [{"ID": f"a{i}"} for i in range(5)]
+    deleted = target.delete_records("Accounts", records)
+
+    params = cur.delete_params()
+    assert len(params) == 3                  # 2 + 2 + 1
+    assert params[0] == ["a0", "a1"]
+    assert params[2] == ["a4"]
+    assert deleted == 5
+
+
+# WHY: empty input is a no-op (and must not touch the connection).
+def test_no_records_is_noop():
+    cur = FakeCursor()
+    target = _make_target(cur)
+
+    assert target.delete_records("Accounts", []) == 0
+    assert cur.executed == []
+    assert target.conn.committed is False
+
+
+# WHY: missing target table -> skip + rollback, never raise.
+def test_missing_table_is_skipped():
+    cur = FakeCursor()
+    target = _make_target(cur, schema_props=None)  # get_table_schema -> None
+
+    deleted = target.delete_records("Ghost", [{"ID": "x"}])
+
+    assert deleted == 0
+    assert cur.delete_params() == []           # no DELETE issued
+    assert target.conn.rolled_back is True
+
+
+# WHY: a PK column absent from the table -> skip + rollback, never raise.
+def test_missing_pk_column_is_skipped():
+    cur = FakeCursor()
+    target = _make_target(cur, schema_props=("OTHER",))
+
+    deleted = target.delete_records("Accounts", [{"ID": "x"}])
+
+    assert deleted == 0
+    assert cur.delete_params() == []
+    assert target.conn.rolled_back is True
+
+
+# WHY: a failure executing the DELETE is best-effort — rolled back, returns 0,
+#      and must NOT propagate (per the ticket: deletes never error the run).
+def test_execute_failure_is_swallowed():
+    cur = FakeCursor(raise_on_delete=True)
+    target = _make_target(cur, schema_props=("ID",))
+
+    deleted = target.delete_records("Accounts", [{"ID": "x"}])
+
+    assert deleted == 0
+    assert target.conn.rolled_back is True


### PR DESCRIPTION
## Reference Ticket
- [PQ-3545](https://app.notion.com/p/peliqan/Tap-peliqan-handle-deleted-rows-37b1aa9b3879801fb668c752f58dca3e)

## Description
Adds support for the `DELETERECORD` Singer message so the Postgres target can delete rows on demand (delete-sync).

- Delete requests are buffered per stream and applied **after** the record batch is flushed, deleting by primary key (`DELETE … WHERE <pk> = …`).
- Streams/tables that aren't present are skipped safely.

## Companion PRs
- tap-peliqan: https://github.com/Peliqan-io/tap-peliqan/pull/137
- baserow: https://github.com/Peliqan-io/baserow/pull/5571
- target-bigquery: https://github.com/Peliqan-io/target-bigquery/pull/8