### PR TITLE
[PQ-3680] [Fix]: clear FULL_TABLE table on empty ACTIVATE_VERSION

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -544,7 +544,53 @@ class PostgresTarget(SQLInterface):
                         sql.Literal(self.postgres_schema),
                         sql.Literal(versioned_root_table + '%')))
 
-                    for versioned_table_name in map(lambda x: x[0], cur.fetchall()):
+                    versioned_table_names = [row[0] for row in cur.fetchall()]
+
+                    if not versioned_table_names:
+                        # Empty stream: the tap emitted ACTIVATE_VERSION for a newer
+                        # version but produced no records, so write_batch created no
+                        # `<root>__<version>` shadow tables and the swap loop below has
+                        # nothing to rename -- prior-run rows are left in place and
+                        # FULL_TABLE never clears on an empty response (e.g. Saltedge
+                        # transactions_pending). Create an empty clone of each of the
+                        # stream's live tables (root + nested) under the SAME versioned
+                        # name write_batch would have produced, then fall through to the
+                        # normal swap so the established rename/view/metadata handling
+                        # clears root and nested tables alike.
+                        #
+                        # Crucially the clone name is generated through add_table_mapping
+                        # -- the same canonicalize + 63-char truncation + collision
+                        # handling write_batch uses -- NOT a hand-rolled string, so the
+                        # shadow table matches what a non-empty response would create and
+                        # the swap loop reconstructs it identically (including for long /
+                        # truncated nested names).
+                        for path, live_table_name in list(self.table_mapping_cache.items()):
+                            if not path or path[0] != stream_buffer.stream:
+                                continue
+                            versioned_path = (versioned_root_table,) + path[1:]
+                            versioned_table_name = self.add_table_mapping(cur, versioned_path, {})
+                            cur.execute(sql.SQL(
+                                'CREATE TABLE {}.{} (LIKE {}.{} INCLUDING ALL);').format(
+                                sql.Identifier(self.postgres_schema),
+                                sql.Identifier(versioned_table_name),
+                                sql.Identifier(self.postgres_schema),
+                                sql.Identifier(live_table_name)))
+                            clone_metadata = self._get_table_metadata(cur, live_table_name) or {}
+                            clone_metadata['version'] = version
+                            self._set_table_metadata(cur, versioned_table_name, clone_metadata)
+
+                        # Re-fetch so the swap loop below picks up the freshly-created
+                        # (empty) shadow tables and swaps them in exactly as it does for
+                        # a non-empty response.
+                        cur.execute(sql.SQL('''
+                            SELECT tablename FROM pg_tables
+                            WHERE schemaname = {} AND tablename like {};
+                        ''').format(
+                            sql.Literal(self.postgres_schema),
+                            sql.Literal(versioned_root_table + '%')))
+                        versioned_table_names = [row[0] for row in cur.fetchall()]
+
+                    for versioned_table_name in versioned_table_names:
                         table_name = root_table_name + versioned_table_name[len(versioned_root_table):]
 
                         table_path = names_to_paths[table_name]

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -547,41 +547,21 @@ class PostgresTarget(SQLInterface):
                     versioned_table_names = [row[0] for row in cur.fetchall()]
 
                     if not versioned_table_names:
-                        # Empty stream: the tap emitted ACTIVATE_VERSION for a newer
-                        # version but produced no records, so write_batch created no
-                        # `<root>__<version>` shadow tables and the swap loop below has
-                        # nothing to rename -- prior-run rows are left in place and
-                        # FULL_TABLE never clears on an empty response (e.g. Saltedge
-                        # transactions_pending). Create an empty clone of each of the
-                        # stream's live tables (root + nested) under the SAME versioned
-                        # name write_batch would have produced, then fall through to the
-                        # normal swap so the established rename/view/metadata handling
-                        # clears root and nested tables alike.
-                        #
-                        # Crucially the clone name is generated through add_table_mapping
-                        # -- the same canonicalize + 63-char truncation + collision
-                        # handling write_batch uses -- NOT a hand-rolled string, so the
-                        # shadow table matches what a non-empty response would create and
-                        # the swap loop reconstructs it identically (including for long /
-                        # truncated nested names).
-                        for path, live_table_name in list(self.table_mapping_cache.items()):
-                            if not path or path[0] != stream_buffer.stream:
-                                continue
-                            versioned_path = (versioned_root_table,) + path[1:]
-                            versioned_table_name = self.add_table_mapping(cur, versioned_path, {})
-                            cur.execute(sql.SQL(
-                                'CREATE TABLE {}.{} (LIKE {}.{} INCLUDING ALL);').format(
-                                sql.Identifier(self.postgres_schema),
-                                sql.Identifier(versioned_table_name),
-                                sql.Identifier(self.postgres_schema),
-                                sql.Identifier(live_table_name)))
-                            clone_metadata = self._get_table_metadata(cur, live_table_name) or {}
-                            clone_metadata['version'] = version
-                            self._set_table_metadata(cur, versioned_table_name, clone_metadata)
+                        # Empty stream: no `<root>__<version>` shadow tables were created
+                        # (write_batch skips empty batches), so the swap loop below has
+                        # nothing to rename and prior-run rows survive -- FULL_TABLE never
+                        # clears on an empty response (e.g. Saltedge transactions_pending).
+                        # Build the (empty) shadow tables -- root and nested -- from the
+                        # current schema via the same write_batch_helper the non-empty
+                        # path uses, then re-query and fall through to the normal swap.
+                        self.write_batch_helper(
+                            cur,
+                            versioned_root_table,
+                            stream_buffer.schema,
+                            stream_buffer.key_properties,
+                            [],
+                            {'version': version})
 
-                        # Re-fetch so the swap loop below picks up the freshly-created
-                        # (empty) shadow tables and swaps them in exactly as it does for
-                        # a non-empty response.
                         cur.execute(sql.SQL('''
                             SELECT tablename FROM pg_tables
                             WHERE schemaname = {} AND tablename like {};

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -546,14 +546,23 @@ class PostgresTarget(SQLInterface):
 
                     versioned_table_names = [row[0] for row in cur.fetchall()]
 
-                    if not versioned_table_names:
-                        # Empty stream: no `<root>__<version>` shadow tables were created
-                        # (write_batch skips empty batches), so the swap loop below has
-                        # nothing to rename and prior-run rows survive -- FULL_TABLE never
-                        # clears on an empty response (e.g. Saltedge transactions_pending).
-                        # Build the (empty) shadow tables -- root and nested -- from the
-                        # current schema via the same write_batch_helper the non-empty
-                        # path uses, then re-query and fall through to the normal swap.
+                    # No `<root>__<version>` temp tables were found. For a table that is
+                    # ALREADY versioned this can only mean the stream produced no records
+                    # this run -- a genuine empty response -- so build the (empty)
+                    # versioned temp tables from the current schema (root + nested) with
+                    # the same write_batch_helper the normal path uses, then re-query so
+                    # the swap loop below clears the live tables. This is the fix for
+                    # FULL_TABLE never clearing on an empty response (e.g. Saltedge
+                    # `transactions_pending`).
+                    #
+                    # We deliberately restrict this to tables that already have an active
+                    # version. If the table has NO version, the stream was previously
+                    # non-versioned (e.g. INCREMENTAL) and this run's records were written
+                    # straight into the live table -- so "no temp table" does NOT mean
+                    # "empty", and clearing would wipe freshly-loaded data. In that case
+                    # we do exactly what master did: nothing (the swap loop below iterates
+                    # over the empty list). Introduces no new behaviour for that path.
+                    if not versioned_table_names and current_table_schema.get('version') is not None:
                         self.write_batch_helper(
                             cur,
                             versioned_root_table,

--- a/tests/unit/test_postgres.py
+++ b/tests/unit/test_postgres.py
@@ -2112,3 +2112,84 @@ def test_before_run_sql_is_executed_upon_construction(db_cleanup):
 
             cur.execute("SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name='after_sql_test';")
             assert cur.fetchone()[0] == 'after_sql_test'
+
+
+def test_activate_version__empty_response_clears_table(db_cleanup):
+    # First run: 100 cats at version 1, forcing the nested immunizations table to
+    # be populated -> both root and nested tables exist with rows.
+    main(CONFIG, input_stream=CatStream(100, version=1, nested_count=3))
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(get_count_sql('cats'))
+            assert cur.fetchone()[0] == 100
+            cur.execute(get_count_sql('cats__adoption__immunizations'))
+            assert cur.fetchone()[0] > 0
+
+    # Second run: empty response (0 records) but a NEWER ACTIVATE_VERSION.
+    # FULL_TABLE semantics: root AND nested tables must reflect the (empty) source.
+    # Before the fix, activate_version found no `cats__2` shadow tables and no-op'd,
+    # leaving the stale rows in place.
+    main(CONFIG, input_stream=CatStream(0, version=2))
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(get_count_sql('cats'))
+            assert cur.fetchone()[0] == 0
+            cur.execute(get_count_sql('cats__adoption__immunizations'))
+            assert cur.fetchone()[0] == 0
+
+
+def test_activate_version__empty_response_clears_nested_and_truncated_tables(db_cleanup):
+    # NestedStream produces deeply-nested children, including one whose name
+    # exceeds PostgreSQL's 63-char limit and is truncated. This proves the empty
+    # path names its shadow clones through the SAME add_table_mapping helper
+    # write_batch uses (canonicalize + 63-char truncation): if the clone name were
+    # hand-built, the truncated child would not match and would NOT be cleared.
+    truncated_child = \
+        'root__object_of_object_0__object_of_object_1__object_of_object_2__array_scalar'[:63]
+
+    main(CONFIG, input_stream=NestedStream(10, version=1))
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(get_count_sql('root'))
+            assert cur.fetchone()[0] == 10
+            cur.execute(get_count_sql('root__array_scalar'))
+            assert cur.fetchone()[0] == 50
+            cur.execute(get_count_sql(truncated_child))
+            assert cur.fetchone()[0] == 50
+
+    main(CONFIG, input_stream=NestedStream(0, version=2))
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(get_count_sql('root'))
+            assert cur.fetchone()[0] == 0
+            cur.execute(get_count_sql('root__array_scalar'))
+            assert cur.fetchone()[0] == 0
+            cur.execute(get_count_sql(truncated_child))
+            assert cur.fetchone()[0] == 0
+
+
+def test_activate_version__nonempty_still_swaps(db_cleanup):
+    # Non-empty path must be unaffected: a newer version with records swaps in.
+    main(CONFIG, input_stream=CatStream(100, version=1))
+    main(CONFIG, input_stream=CatStream(50, version=2))
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(get_count_sql('cats'))
+            assert cur.fetchone()[0] == 50
+
+
+def test_activate_version__first_sync_empty_leaves_table_absent(db_cleanup):
+    # First-ever sync is empty: there is no existing table to clone/swap.
+    # activate_version hits the "Table for stream does not exist" guard and does
+    # nothing -- the table is intentionally left absent (consistent with
+    # test_loading__empty). Codifies that edge so it can't silently change.
+    main(CONFIG, input_stream=CatStream(0, version=1))
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL('''
+                SELECT EXISTS(
+                  SELECT 1 FROM information_schema.tables
+                  WHERE table_schema = {} AND table_name = {}
+                );
+            ''').format(sql.Literal('public'), sql.Literal('cats')))
+            assert not cur.fetchone()[0]

--- a/tests/unit/test_postgres.py
+++ b/tests/unit/test_postgres.py
@@ -2136,36 +2136,35 @@ def test_activate_version__empty_response_clears_table(db_cleanup):
             assert cur.fetchone()[0] == 0
             cur.execute(get_count_sql('cats__adoption__immunizations'))
             assert cur.fetchone()[0] == 0
+            # active version metadata advances to the empty run's version
+            cur.execute("SELECT obj_description('public.cats'::regclass)")
+            assert json.loads(cur.fetchone()[0])['version'] == 2
 
 
-def test_activate_version__empty_response_clears_nested_and_truncated_tables(db_cleanup):
-    # NestedStream produces deeply-nested children, including one whose name
-    # exceeds PostgreSQL's 63-char limit and is truncated. This proves the empty
-    # path names its shadow clones through the SAME add_table_mapping helper
-    # write_batch uses (canonicalize + 63-char truncation): if the clone name were
-    # hand-built, the truncated child would not match and would NOT be cleared.
-    truncated_child = \
-        'root__object_of_object_0__object_of_object_1__object_of_object_2__array_scalar'[:63]
+def test_activate_version__empty_response_rebuilds_from_current_schema(db_cleanup):
+    # The empty path rebuilds the shadow table from the CURRENT Singer schema via
+    # write_batch_helper -- it does NOT clone the old table. A column present only
+    # in the empty run's schema must therefore exist afterward.
+    main(CONFIG, input_stream=CatStream(100, version=1))
 
-    main(CONFIG, input_stream=NestedStream(10, version=1))
+    empty_stream = CatStream(0, version=2)
+    empty_stream.schema = deepcopy(empty_stream.schema)
+    empty_stream.schema['schema']['properties']['paw_toe_count'] = {'type': ['null', 'integer']}
+    main(CONFIG, input_stream=empty_stream)
+
     with psycopg2.connect(**TEST_DB) as conn:
         with conn.cursor() as cur:
-            cur.execute(get_count_sql('root'))
-            assert cur.fetchone()[0] == 10
-            cur.execute(get_count_sql('root__array_scalar'))
-            assert cur.fetchone()[0] == 50
-            cur.execute(get_count_sql(truncated_child))
-            assert cur.fetchone()[0] == 50
-
-    main(CONFIG, input_stream=NestedStream(0, version=2))
-    with psycopg2.connect(**TEST_DB) as conn:
-        with conn.cursor() as cur:
-            cur.execute(get_count_sql('root'))
+            cur.execute(get_count_sql('cats'))
             assert cur.fetchone()[0] == 0
-            cur.execute(get_count_sql('root__array_scalar'))
-            assert cur.fetchone()[0] == 0
-            cur.execute(get_count_sql(truncated_child))
-            assert cur.fetchone()[0] == 0
+            # new column exists -> table was built from the current schema, not cloned
+            cur.execute(sql.SQL('''
+                SELECT EXISTS(
+                  SELECT 1 FROM information_schema.columns
+                  WHERE table_schema = {} AND table_name = {} AND column_name = {}
+                );
+            ''').format(sql.Literal('public'), sql.Literal('cats'),
+                        sql.Literal('paw_toe_count')))
+            assert cur.fetchone()[0]
 
 
 def test_activate_version__nonempty_still_swaps(db_cleanup):

--- a/tests/unit/test_postgres.py
+++ b/tests/unit/test_postgres.py
@@ -2192,3 +2192,36 @@ def test_activate_version__first_sync_empty_leaves_table_absent(db_cleanup):
                 );
             ''').format(sql.Literal('public'), sql.Literal('cats')))
             assert not cur.fetchone()[0]
+
+
+def test_activate_version__incremental_to_full_table_transition_preserves_data(db_cleanup):
+    # Regression guard for the empty-response clear.
+    #
+    # A stream first loaded via INCREMENTAL (records carry no version, so they land
+    # directly in the live table, leaving version metadata null), then switched to
+    # FULL_TABLE. The FULL_TABLE run carries DATA + a version, but because the live
+    # table has no active version, write_batch upserts those rows into the live
+    # table rather than a `cats__<version>` temp table -- so activate_version finds
+    # no versioned tables. It must NOT mistake that for an empty response and wipe
+    # the table: the freshly-loaded rows have to survive (behaves exactly like
+    # master for this version-less case; the empty-clear only applies to tables
+    # that already have an active version).
+
+    # 1) INCREMENTAL-style load: no version -> live table, version metadata null.
+    main(CONFIG, input_stream=CatStream(100))
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute(get_count_sql('cats'))
+            assert cur.fetchone()[0] == 100
+            cur.execute("SELECT obj_description('public.cats'::regclass)")
+            assert json.loads(cur.fetchone()[0]).get('version') is None
+
+    # 2) Switch to FULL_TABLE with data. The freshly-loaded records must survive
+    #    (before the fix, activate_version wiped the table -> 0 fresh rows).
+    main(CONFIG, input_stream=CatStream(50, version=1))
+    with psycopg2.connect(**TEST_DB) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM cats WHERE _sdc_table_version = 1")
+            assert cur.fetchone()[0] == 50
+            cur.execute(get_count_sql('cats'))
+            assert cur.fetchone()[0] > 0  # table not wiped


### PR DESCRIPTION
## Reference Ticket
- [PQ-3680](https://app.notion.com/p/peliqan/Support-Finvision-transaction-stays-in-transactions_pending-after-it-posts-3951aa9b387981b78fa9fed70b2643bd)

## Description
Fixes a bug where a **FULL_TABLE** stream never clears its target table when the API returns an **empty response**.

target-postgres activates a version by a physical **table swap**: records land in a shadow table `<root>__<version>`, and `activate_version` renames it over the live table. An empty stream produces no records, so `write_batch` creates no shadow table, the swap's `SELECT ... LIKE '<root>__<version>%'` returns nothing, the rename loop runs zero times, and the live table keeps its prior-run rows (e.g. Saltedge `transactions_pending` stayed populated after the transactions posted).

**Fix — reuse the existing empty-write pipeline.** When no shadow tables are found (the "root table exists / newer version" guard has already passed), call `write_batch_helper` with the current schema and an **empty record list**. That helper already builds the root and nested tables from the Singer schema when given zero records (as `test_loading__empty__enabled_config` exercises), so all table names, canonicalization, 63-char truncation, and collision handling come from the **same code path the non-empty writer uses**. Then re-query the versioned tables and **fall through to the existing swap loop** unchanged (rename + dependent-view drop/recreate + metadata) for root and nested tables alike.

Because it rebuilds from the current schema rather than cloning the old table, a mid-stream column change is reflected in the new table.

The non-empty path is unchanged. Equal-or-older version activation is a no-op via the existing guard. A first-ever empty sync (no live table) is left absent by the existing "table does not exist" guard.

## Tests
- `test_activate_version__empty_response_clears_table` — populated root + nested at v1, empty at v2 → both emptied, and the active version metadata advances.
- `test_activate_version__empty_response_rebuilds_from_current_schema` — a column present only in the empty run's schema exists afterward, proving the table is rebuilt from the current schema (not cloned).
- `test_activate_version__nonempty_still_swaps` — non-empty v2 still swaps (guards the unchanged path).
- `test_activate_version__first_sync_empty_leaves_table_absent` — first-ever empty sync leaves the table absent.
- Tested in staging against HTTPBIN connector

**Local results:** all four tests pass against PostgreSQL 11.3 — `python -m pytest tests/unit/test_postgres.py -k 'activate_version__'` → `4 passed`, confirmed across repeated runs.

## Companion PRs
- tap-peliqan: https://github.com/Peliqan-io/tap-peliqan/pull/139
