### PR TITLE
[PQ-3978] [Chore]: reduce target logs — drop Mapping and METRIC lines

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -383,10 +383,6 @@ class PostgresTarget(SQLInterface):
 
         return ordered_deps
 
-    def metrics_tags(self):
-        return {'database': self.conn.get_dsn_parameters().get('dbname', None),
-                'schema': self.postgres_schema}
-
     def setup_table_mapping_cache(self, cur):
         self.table_mapping_cache = {}
 
@@ -401,7 +397,7 @@ class PostgresTarget(SQLInterface):
             table_path = None
             if raw_json:
                 table_path = json.loads(raw_json).get('path', None)
-            self.LOGGER.info("Mapping: {} to {}".format(mapped_name, table_path))
+            self.LOGGER.debug("Mapping: {} to {}".format(mapped_name, table_path))
             if table_path:
                 self.table_mapping_cache[tuple(table_path)] = mapped_name
 

--- a/target_postgres/sql_base.py
+++ b/target_postgres/sql_base.py
@@ -18,7 +18,6 @@ import pickle
 import time
 
 import singer
-import singer.metrics as metrics
 
 from target_postgres import denest
 from target_postgres import json_schema
@@ -54,34 +53,6 @@ class SQLInterface:
 
     IDENTIFIER_FIELD_LENGTH = NotImplementedError('`IDENTIFIER_FIELD_LENGTH` not implemented.')
     LOGGER = singer.get_logger(is_target=True)
-
-    def _set_timer_tags(self, metric, job_type, path):
-        metric.tags['job_type'] = job_type
-        metric.tags['path'] = path
-
-        metric.tags.update(self.metrics_tags())
-
-        return metric
-
-    def _set_counter_tags(self, metric, counter_type, path):
-        metric.tags['count_type'] = counter_type
-        metric.tags['path'] = path
-
-        metric.tags.update(self.metrics_tags())
-
-        return metric
-
-    def _set_metrics_tags__table(self, metric, table_name):
-        metric.tags['table'] = table_name
-
-        return metric
-
-    def metrics_tags(self):
-        """
-        Optional function to overwrite to include more tags into Singer Metrics.
-        :return: Dictonary of Tags
-        """
-        return {}
 
     def json_schema_to_sql_type(self, schema):
         """
@@ -384,254 +355,248 @@ class SQLInterface:
         """
         table_path = schema['path']
 
-        with self._set_timer_tags(metrics.job_timer(is_target=True),
-                                  'upsert_table_schema',
-                                  table_path) as timer:
+        _metadata = deepcopy(metadata)
+        _metadata['schema_version'] = CURRENT_SCHEMA_VERSION
 
-            _metadata = deepcopy(metadata)
-            _metadata['schema_version'] = CURRENT_SCHEMA_VERSION
+        table_name = self.add_table_mapping(connection, table_path, _metadata)
 
-            table_name = self.add_table_mapping(connection, table_path, _metadata)
+        existing_schema = self._get_table_schema(connection, table_name)
 
-            self._set_metrics_tags__table(timer, table_name)
-
+        existing_table = True
+        if existing_schema is None:
+            self.add_table(connection, table_path, table_name, _metadata)
             existing_schema = self._get_table_schema(connection, table_name)
+            existing_table = False
 
-            existing_table = True
-            if existing_schema is None:
-                self.add_table(connection, table_path, table_name, _metadata)
-                existing_schema = self._get_table_schema(connection, table_name)
-                existing_table = False
+        self.add_key_properties(connection, table_name, schema.get('key_properties', None))
 
-            self.add_key_properties(connection, table_name, schema.get('key_properties', None))
+        ## Build up mappings to compare new columns against existing
+        mappings = []
 
-            ## Build up mappings to compare new columns against existing
-            mappings = []
+        for to, m in existing_schema.get('mappings', {}).items():
+            mapping = json_schema.simple_type(m)
+            mapping['from'] = tuple(m['from'])
+            mapping['to'] = to
+            mappings.append(mapping)
 
-            for to, m in existing_schema.get('mappings', {}).items():
-                mapping = json_schema.simple_type(m)
-                mapping['from'] = tuple(m['from'])
-                mapping['to'] = to
-                mappings.append(mapping)
+        ## Only process columns which have single, nullable, types
+        column_paths_seen = set()
+        single_type_columns = []
 
-            ## Only process columns which have single, nullable, types
-            column_paths_seen = set()
-            single_type_columns = []
+        for column_path, column_schema in schema['schema']['properties'].items():
+            column_paths_seen.add(column_path)
+            for sub_schema in column_schema['anyOf']:
+                single_type_columns.append((column_path, deepcopy(sub_schema)))
 
-            for column_path, column_schema in schema['schema']['properties'].items():
-                column_paths_seen.add(column_path)
-                for sub_schema in column_schema['anyOf']:
-                    single_type_columns.append((column_path, deepcopy(sub_schema)))
+        ### Add any columns missing from new schema
+        for m in mappings:
+            if not m['from'] in column_paths_seen:
+                single_type_columns.append((m['from'], json_schema.make_nullable(m)))
 
-            ### Add any columns missing from new schema
-            for m in mappings:
-                if not m['from'] in column_paths_seen:
-                    single_type_columns.append((m['from'], json_schema.make_nullable(m)))
+        ## Process new columns against existing
+        table_empty = self.is_table_empty(connection, table_name)
 
-            ## Process new columns against existing
-            table_empty = self.is_table_empty(connection, table_name)
+        for column_path, column_schema in single_type_columns:
+            upsert_table_helper__start__column = time.monotonic()
 
-            for column_path, column_schema in single_type_columns:
-                upsert_table_helper__start__column = time.monotonic()
+            canonicalized_column_name = self._canonicalize_column_identifier(column_path, column_schema, mappings)
+            nullable_column_schema = json_schema.make_nullable(column_schema)
 
-                canonicalized_column_name = self._canonicalize_column_identifier(column_path, column_schema, mappings)
-                nullable_column_schema = json_schema.make_nullable(column_schema)
-
-                def log_message(msg):
-                    if log_schema_changes:
-                        self.LOGGER.info(
-                            'Table Schema Change [`{}`.`{}`:`{}`] {} (took {} millis)'.format(
-                                table_name,
-                                column_path,
-                                canonicalized_column_name,
-                                msg,
-                                _duration_millis(upsert_table_helper__start__column)))
-
-                ## NEW COLUMN
-                if not column_path in [m['from'] for m in mappings]:
-                    upsert_table_helper__column = "New column"
-                    ### NON EMPTY TABLE
-                    if not table_empty:
-                        upsert_table_helper__column += ", non empty table"
-                        self.LOGGER.warning(
-                            'NOT EMPTY: Forcing new column `{}` in table `{}` to be nullable due to table not empty.'.format(
-                                column_path,
-                                table_name))
-                        column_schema = nullable_column_schema
-
-                    self.add_column(connection,
-                                    table_name,
-                                    canonicalized_column_name,
-                                    column_schema)
-                    
-                    
-                    self.add_column_mapping(connection,
-                                            table_name,
-                                            column_path,
-                                            canonicalized_column_name,
-                                            column_schema)
-
-                    mapping = json_schema.simple_type(column_schema)
-                    mapping['from'] = column_path
-                    mapping['to'] = canonicalized_column_name
-                    mappings.append(mapping)
-
-                    log_message(upsert_table_helper__column)
-
-                    continue
-
-                ## EXISTING COLUMNS
-                ### SCHEMAS MATCH
-                if [True for m in mappings if
-                    m['from'] == column_path
-                    and self.json_schema_to_sql_type(m) == self.json_schema_to_sql_type(column_schema)]:
-                    continue
-                ### NULLABLE SCHEMAS MATCH
-                ###  New column _is not_ nullable, existing column _is_
-                if [True for m in mappings if
-                    m['from'] == column_path
-                    and self.json_schema_to_sql_type(m) == self.json_schema_to_sql_type(nullable_column_schema)]:
-                    continue
-
-                ### NULL COMPATIBILITY
-                ###  New column _is_ nullable, existing column is _not_
-                non_null_original_column = [m for m in mappings if
-                                            m['from'] == column_path and json_schema.shorthand(
-                                                m) == json_schema.shorthand(column_schema)]
-                if non_null_original_column:
-                    ## MAKE NULLABLE
-                    self.make_column_nullable(connection,
-                                              table_name,
-                                              canonicalized_column_name)
-                    self.drop_column_mapping(connection, table_name, canonicalized_column_name)
-                    self.add_column_mapping(connection,
-                                            table_name,
-                                            column_path,
-                                            canonicalized_column_name,
-                                            nullable_column_schema)
-
-                    mappings = [m for m in mappings if not (m['from'] == column_path and json_schema.shorthand(
-                        m) == json_schema.shorthand(column_schema))]
-
-                    mapping = json_schema.simple_type(nullable_column_schema)
-                    mapping['from'] = column_path
-                    mapping['to'] = canonicalized_column_name
-                    mappings.append(mapping)
-
-                    log_message("Made existing column nullable.")
-
-                    continue
-
-                ### FIRST MULTI TYPE
-                ###  New column matches existing column path, but the types are incompatible
-                duplicate_paths = [m for m in mappings if m['from'] == column_path]
-
-                if 1 == len(duplicate_paths):
-                    existing_mapping = duplicate_paths[0]
-                    existing_column_name = existing_mapping['to']
-
-                    if existing_column_name:
-                        self.drop_column_mapping(connection, table_name, existing_column_name)
-
-                    ## Update existing properties
-                    mappings = [m for m in mappings if m['from'] != column_path]
-
-                    mapping = json_schema.simple_type(nullable_column_schema)
-                    mapping['from'] = column_path
-                    mapping['to'] = canonicalized_column_name
-                    mappings.append(mapping)
-
-                    existing_column_new_normalized_name = self._canonicalize_column_identifier(column_path,
-                                                                                               existing_mapping,
-                                                                                               mappings)
-
-                    mapping = json_schema.simple_type(json_schema.make_nullable(existing_mapping))
-                    mapping['from'] = column_path
-                    mapping['to'] = existing_column_new_normalized_name
-                    mappings.append(mapping)
-
-                    ## Add new columns
-                    ### NOTE: all migrated columns will be nullable and remain that way
-
-                    #### Table Metadata
-                    self.add_column_mapping(connection,
-                                            table_name,
-                                            column_path,
-                                            existing_column_new_normalized_name,
-                                            json_schema.make_nullable(existing_mapping))
-                    self.add_column_mapping(connection,
-                                            table_name,
-                                            column_path,
-                                            canonicalized_column_name,
-                                            nullable_column_schema)
-
-                    #### Columns
-                    self.add_column(connection,
-                                    table_name,
-                                    existing_column_new_normalized_name,
-                                    json_schema.make_nullable(existing_mapping))
-
-                    self.add_column(connection,
-                                    table_name,
-                                    canonicalized_column_name,
-                                    nullable_column_schema)
-
-                    ## Migrate existing data
-                    self.migrate_column(connection,
-                                        table_name,
-                                        existing_mapping['to'],
-                                        existing_column_new_normalized_name)
-
-                    ## Drop existing column
-                    self.drop_column(connection,
-                                     table_name,
-                                     existing_mapping['to'])
-
-                    upsert_table_helper__column = "Splitting `{}` into `{}` and `{}`. New column matches existing column path, but the types are incompatible.".format(
-                        existing_column_name,
-                        existing_column_new_normalized_name,
-                        canonicalized_column_name
-                    )
-
-                ## REST MULTI TYPE
-                elif 1 < len(duplicate_paths):
-                    ## Add new column
-                    self.add_column_mapping(connection,
-                                            table_name,
-                                            column_path,
-                                            canonicalized_column_name,
-                                            nullable_column_schema)
-                    self.add_column(connection,
-                                    table_name,
-                                    canonicalized_column_name,
-                                    nullable_column_schema)
-
-                    mapping = json_schema.simple_type(nullable_column_schema)
-                    mapping['from'] = column_path
-                    mapping['to'] = canonicalized_column_name
-                    mappings.append(mapping)
-
-                    upsert_table_helper__column = "Adding new column to split column `{}`. New column matches existing column's path, but no types were compatible.".format(
-                        column_path
-                    )
-
-                ## UNKNOWN
-                else:
-                    raise Exception(
-                        'UNKNOWN: Cannot handle merging column `{}` (canonicalized as: `{}`) in table `{}`.'.format(
+            def log_message(msg):
+                if log_schema_changes:
+                    self.LOGGER.info(
+                        'Table Schema Change [`{}`.`{}`:`{}`] {} (took {} millis)'.format(
+                            table_name,
                             column_path,
                             canonicalized_column_name,
-                            table_name
-                        ))
+                            msg,
+                            _duration_millis(upsert_table_helper__start__column)))
+
+            ## NEW COLUMN
+            if not column_path in [m['from'] for m in mappings]:
+                upsert_table_helper__column = "New column"
+                ### NON EMPTY TABLE
+                if not table_empty:
+                    upsert_table_helper__column += ", non empty table"
+                    self.LOGGER.warning(
+                        'NOT EMPTY: Forcing new column `{}` in table `{}` to be nullable due to table not empty.'.format(
+                            column_path,
+                            table_name))
+                    column_schema = nullable_column_schema
+
+                self.add_column(connection,
+                                table_name,
+                                canonicalized_column_name,
+                                column_schema)
+                
+                
+                self.add_column_mapping(connection,
+                                        table_name,
+                                        column_path,
+                                        canonicalized_column_name,
+                                        column_schema)
+
+                mapping = json_schema.simple_type(column_schema)
+                mapping['from'] = column_path
+                mapping['to'] = canonicalized_column_name
+                mappings.append(mapping)
 
                 log_message(upsert_table_helper__column)
 
-            if not existing_table:
-                for column_names in self.new_table_indexes(schema):
-                    self.add_index(connection, table_name, column_names)
-                self.add_primary_key(connection, table_name, schema.get('key_properties', None))
+                continue
 
-            return self._get_table_schema(connection, table_name)
+            ## EXISTING COLUMNS
+            ### SCHEMAS MATCH
+            if [True for m in mappings if
+                m['from'] == column_path
+                and self.json_schema_to_sql_type(m) == self.json_schema_to_sql_type(column_schema)]:
+                continue
+            ### NULLABLE SCHEMAS MATCH
+            ###  New column _is not_ nullable, existing column _is_
+            if [True for m in mappings if
+                m['from'] == column_path
+                and self.json_schema_to_sql_type(m) == self.json_schema_to_sql_type(nullable_column_schema)]:
+                continue
+
+            ### NULL COMPATIBILITY
+            ###  New column _is_ nullable, existing column is _not_
+            non_null_original_column = [m for m in mappings if
+                                        m['from'] == column_path and json_schema.shorthand(
+                                            m) == json_schema.shorthand(column_schema)]
+            if non_null_original_column:
+                ## MAKE NULLABLE
+                self.make_column_nullable(connection,
+                                          table_name,
+                                          canonicalized_column_name)
+                self.drop_column_mapping(connection, table_name, canonicalized_column_name)
+                self.add_column_mapping(connection,
+                                        table_name,
+                                        column_path,
+                                        canonicalized_column_name,
+                                        nullable_column_schema)
+
+                mappings = [m for m in mappings if not (m['from'] == column_path and json_schema.shorthand(
+                    m) == json_schema.shorthand(column_schema))]
+
+                mapping = json_schema.simple_type(nullable_column_schema)
+                mapping['from'] = column_path
+                mapping['to'] = canonicalized_column_name
+                mappings.append(mapping)
+
+                log_message("Made existing column nullable.")
+
+                continue
+
+            ### FIRST MULTI TYPE
+            ###  New column matches existing column path, but the types are incompatible
+            duplicate_paths = [m for m in mappings if m['from'] == column_path]
+
+            if 1 == len(duplicate_paths):
+                existing_mapping = duplicate_paths[0]
+                existing_column_name = existing_mapping['to']
+
+                if existing_column_name:
+                    self.drop_column_mapping(connection, table_name, existing_column_name)
+
+                ## Update existing properties
+                mappings = [m for m in mappings if m['from'] != column_path]
+
+                mapping = json_schema.simple_type(nullable_column_schema)
+                mapping['from'] = column_path
+                mapping['to'] = canonicalized_column_name
+                mappings.append(mapping)
+
+                existing_column_new_normalized_name = self._canonicalize_column_identifier(column_path,
+                                                                                           existing_mapping,
+                                                                                           mappings)
+
+                mapping = json_schema.simple_type(json_schema.make_nullable(existing_mapping))
+                mapping['from'] = column_path
+                mapping['to'] = existing_column_new_normalized_name
+                mappings.append(mapping)
+
+                ## Add new columns
+                ### NOTE: all migrated columns will be nullable and remain that way
+
+                #### Table Metadata
+                self.add_column_mapping(connection,
+                                        table_name,
+                                        column_path,
+                                        existing_column_new_normalized_name,
+                                        json_schema.make_nullable(existing_mapping))
+                self.add_column_mapping(connection,
+                                        table_name,
+                                        column_path,
+                                        canonicalized_column_name,
+                                        nullable_column_schema)
+
+                #### Columns
+                self.add_column(connection,
+                                table_name,
+                                existing_column_new_normalized_name,
+                                json_schema.make_nullable(existing_mapping))
+
+                self.add_column(connection,
+                                table_name,
+                                canonicalized_column_name,
+                                nullable_column_schema)
+
+                ## Migrate existing data
+                self.migrate_column(connection,
+                                    table_name,
+                                    existing_mapping['to'],
+                                    existing_column_new_normalized_name)
+
+                ## Drop existing column
+                self.drop_column(connection,
+                                 table_name,
+                                 existing_mapping['to'])
+
+                upsert_table_helper__column = "Splitting `{}` into `{}` and `{}`. New column matches existing column path, but the types are incompatible.".format(
+                    existing_column_name,
+                    existing_column_new_normalized_name,
+                    canonicalized_column_name
+                )
+
+            ## REST MULTI TYPE
+            elif 1 < len(duplicate_paths):
+                ## Add new column
+                self.add_column_mapping(connection,
+                                        table_name,
+                                        column_path,
+                                        canonicalized_column_name,
+                                        nullable_column_schema)
+                self.add_column(connection,
+                                table_name,
+                                canonicalized_column_name,
+                                nullable_column_schema)
+
+                mapping = json_schema.simple_type(nullable_column_schema)
+                mapping['from'] = column_path
+                mapping['to'] = canonicalized_column_name
+                mappings.append(mapping)
+
+                upsert_table_helper__column = "Adding new column to split column `{}`. New column matches existing column's path, but no types were compatible.".format(
+                    column_path
+                )
+
+            ## UNKNOWN
+            else:
+                raise Exception(
+                    'UNKNOWN: Cannot handle merging column `{}` (canonicalized as: `{}`) in table `{}`.'.format(
+                        column_path,
+                        canonicalized_column_name,
+                        table_name
+                    ))
+
+            log_message(upsert_table_helper__column)
+
+        if not existing_table:
+            for column_names in self.new_table_indexes(schema):
+                self.add_index(connection, table_name, column_names)
+            self.add_primary_key(connection, table_name, schema.get('key_properties', None))
+
+        return self._get_table_schema(connection, table_name)
 
     def _serialize_table_record_field_name(self, remote_schema, path, value_json_schema_tuple):
         """
@@ -835,59 +800,45 @@ class SQLInterface:
         :return: {'records_persisted': int,
                   'rows_persisted': int}
         """
-        with self._set_timer_tags(metrics.job_timer(is_target=True),
-                                  'batch',
-                                  (root_table_name,)):
-            with self._set_counter_tags(metrics.record_counter(None, is_target=True),
-                                        'batch_rows_persisted',
-                                        (root_table_name,)) as batch_counter:
-                self.LOGGER.info('Writing batch with {} records for `{}` with `key_properties`: `{}`'.format(
-                    len(records),
-                    root_table_name,
-                    key_properties
-                ))
+        self.LOGGER.info('Writing batch with {} records for `{}` with `key_properties`: `{}`'.format(
+            len(records),
+            root_table_name,
+            key_properties
+        ))
 
-                for table_batch in denest.to_table_batches(schema, key_properties, records):
-                    table_batch['streamed_schema']['path'] = (root_table_name,) + \
-                                                             table_batch['streamed_schema']['path']
+        rows_persisted = 0
 
-                    with self._set_timer_tags(metrics.job_timer(is_target=True),
-                                              'table',
-                                              table_batch['streamed_schema']['path']) as table_batch_timer:
-                        with self._set_counter_tags(metrics.record_counter(None, is_target=True),
-                                                    'table_rows_persisted',
-                                                    table_batch['streamed_schema']['path']) as table_batch_counter:
-                            self.LOGGER.info('Writing table batch schema for `{}`...'.format(
-                                table_batch['streamed_schema']['path']
-                            ))
+        for table_batch in denest.to_table_batches(schema, key_properties, records):
+            table_batch['streamed_schema']['path'] = (root_table_name,) + \
+                                                     table_batch['streamed_schema']['path']
 
-                            remote_schema = self.upsert_table_helper(connection,
-                                                                     table_batch['streamed_schema'],
-                                                                     metadata)
+            self.LOGGER.info('Writing table batch schema for `{}`...'.format(
+                table_batch['streamed_schema']['path']
+            ))
 
-                            self._set_metrics_tags__table(table_batch_timer, remote_schema['name'])
-                            self._set_metrics_tags__table(table_batch_counter, remote_schema['name'])
+            remote_schema = self.upsert_table_helper(connection,
+                                                     table_batch['streamed_schema'],
+                                                     metadata)
 
-                            self.LOGGER.info('Writing table batch with {} rows for `{}`...'.format(
-                                len(table_batch['records']),
-                                table_batch['streamed_schema']['path']
-                            ))
+            self.LOGGER.info('Writing table batch with {} rows for `{}`...'.format(
+                len(table_batch['records']),
+                table_batch['streamed_schema']['path']
+            ))
 
-                            batch_rows_persisted = self.write_table_batch(
-                                connection,
-                                {'remote_schema': remote_schema,
-                                 'records': self._serialize_table_records(remote_schema,
-                                                                          table_batch['streamed_schema'],
-                                                                          table_batch['records'])},
-                                metadata)
+            batch_rows_persisted = self.write_table_batch(
+                connection,
+                {'remote_schema': remote_schema,
+                 'records': self._serialize_table_records(remote_schema,
+                                                          table_batch['streamed_schema'],
+                                                          table_batch['records'])},
+                metadata)
 
-                            table_batch_counter.increment(batch_rows_persisted)
-                            batch_counter.increment(batch_rows_persisted)
+            rows_persisted += batch_rows_persisted
 
-                return {
-                    'records_persisted': len(records),
-                    'rows_persisted': batch_counter.value
-                }
+        return {
+            'records_persisted': len(records),
+            'rows_persisted': rows_persisted
+        }
 
     def write_batch(self, stream_buffer):
         """

--- a/target_postgres/target_tools.py
+++ b/target_postgres/target_tools.py
@@ -8,7 +8,7 @@ import decimal
 import urllib.parse
 
 import singer
-from singer import utils, metadata, metrics
+from singer import utils, metadata
 
 from target_postgres import json_schema
 from target_postgres.exceptions import TargetError


### PR DESCRIPTION
## Reference Ticket
- [PQ-3978](https://app.notion.com/p/peliqan/Reduce-logs-of-Postgres-Singer-target-3c11aa9b38798003aa39e9842e7c1b3a)

## Description
Removes the two log lines that made up the bulk of every Singer pipeline log, cutting retained log volume (and its S3 cost) without losing anything that was being used.

- **`Mapping:`** — emitted once per relation in the target schema, every time the table mapping cache was refreshed. Because a flush is forced on every STATE message, this repeated for each batch. It also covered indexes and sequences, not just tables, so most lines carried no mapping at all and read `... to None`. Now logged at debug, so it remains available via the `logging_level` config key when diagnosing table name mangling.
- **`METRIC:`** — timing and row-count metrics emitted per batch, per table batch, and per schema upsert. Nothing reads them: there is no consumer of METRIC log lines on the Peliqan side, and the row count they produced was discarded by the caller. The instrumentation is removed rather than silenced.

Side effect worth noting: the removed counter reset itself every 60s, so long-running batches under-reported their persisted row count. The replacement accumulator is correct.

Real errors are now visible in pipeline logs instead of buried.

## Tests

All tests ran through the Peliqan pipeline (HTTPBIN connector → target-postgres) against PostgreSQL, comparing this branch against `master` deployed into the same singer worker.

### 1. Full pipeline, 6 streams, steady state
FULL_TABLE, INCREMENTAL and a nested stream; 9,500 source records into 8 target tables.

| | master | this branch | change |
|---|---|---|---|
| Log size | 269,697 B | 47,933 B | **−82.2%** |
| Log lines | 2,140 | 372 | −82.6% |
| `Mapping:` lines | 1,458 | 0 | — |
| `METRIC:` lines | 310 | 0 | — |

- Identical workload in both runs: 50 batches, 70 table batches, 62 schema changes, 50 streams.
- Row counts identical across all 8 tables including denested child tables.
- All 86 columns identical. All 16 index definitions identical.
- Both runs exited 0 from source and target, no errors or tracebacks.
- Every distinct log message shape compared between runs: 78 shapes removed (42 `Mapping`, 36 `METRIC`), no other shape lost, no new shape introduced.

### 2. Deep denesting (depth-2 arrays and objects)
Stream containing an object holding an array, an array of objects each holding a further array, and an array of arrays. 500 parent records → 6 tables, two at depth 2 (carrying both `_sdc_level_0_id` and `_sdc_level_1_id`).

| table | rows | depth |
|---|---|---|
| `deep` | 500 | root |
| `deep__profile__entries` | 1,500 | 1 |
| `deep__items` | 1,000 | 1 |
| `deep__items__parts` | 1,500 | **2** |
| `deep__matrix` | 1,000 | 1 |
| `deep__matrix___sdc_value` | 2,500 | **2** |

- Row counts identical in all six tables (8,000 rows).
- Column structure identical (29 columns).
- Two-way `EXCEPT` on every table returns 0 differing rows.
- Log size 88,941 B → 19,161 B (−78.5%).
- Error propagation verified unchanged: a failing write raised `PostgresError` and exited non-zero identically on both.

### 3. Schema drift and column migration (17 cases)
Each case loaded at `drift=0`, re-discovered at `drift=1`, then re-synced so the schema change reaches the target: add column, drop column, int→float widen, string→int narrow, string→bool, date→string, always-null, rename, nested field add, nested field drop, array element type change, mixed types in one batch, case collision, over-length identifier, precision growth, scalar→object, and a steady-state control.

Migrations confirmed to have fired: `widen` produced `quantity__i`/`quantity__f`, `narrow` produced `code__s`/`code__i`, `add_column` added `costcentercode`, `rename` added `costcenter_code` and orphaned `legacy`, `nested_add` added `nested_b`, `case_collide` produced `code__1`, `long_name` truncated to a 63-character identifier.

| | master | this branch |
|---|---|---|
| Columns across all tables | 283 | 283 (identical) |
| Data rows | 160 | 160 (identical, including split and renamed columns) |
| Schema changes performed | 11 | 11 |
| Log size | 135,598 B | 14,124 B (**−89.6%**) |

### 4. ACTIVATE_VERSION and dependent-view recreation
A dependent view was created on a FULL_TABLE stream's target table, then a full sync run on each branch so the version swap had to drop and recreate it.

Present and working on both master and this branch:

| log line | master | branch |
|---|---|---|
| `Stream ... with max_version ... targetting ...` | 50 | 50 |
| `Fetching direct dependencies for ...` | ✓ | ✓ |
| `Dependent views found: [...]` | ✓ | ✓ |
| `Dropping dependent view "..." with metadata:` | 1 | 1 |
| `Recreating dependent view "..." with metadata:` | 1 | 1 |
| `Activated {...}, setting path to ...` | 6 | 6 |

Diffing all of these lines between the two runs: identical, 22/22. The view survived the swap with correct data (1,499 rows) on both runs, with zero errors logged.
